### PR TITLE
履歴一覧のダブルクリックで生成画像を開けるようにする

### DIFF
--- a/WondayWall/ViewModels/MainWindowViewModel.cs
+++ b/WondayWall/ViewModels/MainWindowViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.Logging;

--- a/WondayWall/ViewModels/MainWindowViewModel.cs
+++ b/WondayWall/ViewModels/MainWindowViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.Logging;
@@ -242,6 +243,37 @@ public partial class MainWindowViewModel : ObservableObject
     {
         if (!string.IsNullOrEmpty(url))
             RssSources.Remove(url);
+    }
+
+    [RelayCommand]
+    private void OpenHistoryImage(HistoryItem? item)
+    {
+        var imagePath = item?.AppliedImagePath;
+        if (string.IsNullOrWhiteSpace(imagePath))
+        {
+            LastResultMessage = "画像パスがありません。";
+            return;
+        }
+
+        if (!File.Exists(imagePath))
+        {
+            LastResultMessage = $"画像ファイルが見つかりません: {imagePath}";
+            return;
+        }
+
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = imagePath,
+                UseShellExecute = true,
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "履歴画像を開けませんでした: {ImagePath}", imagePath);
+            LastResultMessage = $"画像を開けませんでした: {ex.Message}";
+        }
     }
 
     private void LoadHistory()

--- a/WondayWall/Views/MainWindow.xaml
+++ b/WondayWall/Views/MainWindow.xaml
@@ -102,7 +102,11 @@
                             FontSize="16"
                             FontWeight="SemiBold"
                             Text="実行履歴" />
-                        <ui:ListView MinHeight="200" ItemsSource="{Binding History}">
+                        <ui:ListView
+                            x:Name="HistoryListView"
+                            MinHeight="200"
+                            ItemsSource="{Binding History}"
+                            MouseDoubleClick="HistoryListView_OnMouseDoubleClick">
                             <ui:ListView.View>
                                 <ui:GridView>
                                     <GridViewColumn

--- a/WondayWall/Views/MainWindow.xaml.cs
+++ b/WondayWall/Views/MainWindow.xaml.cs
@@ -1,4 +1,3 @@
-using System.Windows.Controls;
 using System.Windows.Input;
 using WondayWall.Models;
 using WondayWall.ViewModels;
@@ -17,7 +16,7 @@ public partial class MainWindow : FluentWindow
 
     private void HistoryListView_OnMouseDoubleClick(object sender, MouseButtonEventArgs e)
     {
-        if (sender is not ListView { SelectedItem: HistoryItem historyItem })
+        if (sender is not Wpf.Ui.Controls.ListView { SelectedItem: HistoryItem historyItem })
             return;
 
         if (DataContext is not MainWindowViewModel viewModel)

--- a/WondayWall/Views/MainWindow.xaml.cs
+++ b/WondayWall/Views/MainWindow.xaml.cs
@@ -1,3 +1,7 @@
+using System.Windows.Controls;
+using System.Windows.Input;
+using WondayWall.Models;
+using WondayWall.ViewModels;
 using Wpf.Ui.Appearance;
 using Wpf.Ui.Controls;
 
@@ -9,5 +13,16 @@ public partial class MainWindow : FluentWindow
     {
         SystemThemeWatcher.Watch(this);
         InitializeComponent();
+    }
+
+    private void HistoryListView_OnMouseDoubleClick(object sender, MouseButtonEventArgs e)
+    {
+        if (sender is not ListView { SelectedItem: HistoryItem historyItem })
+            return;
+
+        if (DataContext is not MainWindowViewModel viewModel)
+            return;
+
+        viewModel.OpenHistoryImageCommand.Execute(historyItem);
     }
 }


### PR DESCRIPTION
## 概要
- 実行履歴の項目をダブルクリックしたときに、生成済み画像を既定のビューアで開けるようにしました
- 画像パスがない場合やファイルが見つからない場合は、既存の結果メッセージへエラーを表示します

## 変更内容
- `MainWindowViewModel` に履歴画像を開くコマンドを追加
- 履歴 `ListView` にダブルクリックイベントを接続
- コードビハインドから選択中の `HistoryItem` を ViewModel コマンドへ渡すように変更

Closes #23