### PR TITLE
[codex] issue #33 アプリ内の日時型をDateTimeに統一

### DIFF
--- a/WondayWall/Commands/CliCommands.cs
+++ b/WondayWall/Commands/CliCommands.cs
@@ -17,7 +17,7 @@ public class CliCommands(
     public async Task RunOnceAsync(CancellationToken cancellationToken = default)
     {
         var skipIfNoChanges = configService.Current.SkipGenerationWhenNoChanges;
-        var result = await coordinator.RunScheduledAsync(skipIfNoChanges, DateTimeOffset.Now, cancellationToken);
+        var result = await coordinator.RunScheduledAsync(skipIfNoChanges, DateTime.Now, cancellationToken);
         if (result is null)
         {
             logger.LogInformation("Skipping scheduled run: current slot is already handled.");

--- a/WondayWall/Models/CalendarEventItem.cs
+++ b/WondayWall/Models/CalendarEventItem.cs
@@ -2,7 +2,7 @@ namespace WondayWall.Models;
 
 public record CalendarEventItem(
     string Title,
-    DateTimeOffset StartTime,
-    DateTimeOffset? EndTime = null,
+    DateTime StartTime,
+    DateTime? EndTime = null,
     string? Location = null,
     string? Description = null);

--- a/WondayWall/Models/GeneratedImageInfo.cs
+++ b/WondayWall/Models/GeneratedImageInfo.cs
@@ -2,6 +2,6 @@ namespace WondayWall.Models;
 
 public record GeneratedImageInfo(
     string FilePath,
-    DateTimeOffset GeneratedAt,
+    DateTime GeneratedAt,
     string UsedPrompt,
     PromptContext? SourceContext = null);

--- a/WondayWall/Models/HistoryItem.cs
+++ b/WondayWall/Models/HistoryItem.cs
@@ -1,7 +1,7 @@
 namespace WondayWall.Models;
 
 public record HistoryItem(
-    DateTimeOffset ExecutedAt,
+    DateTime ExecutedAt,
     bool IsSuccess,
     string? ErrorSummary = null,
     string? AppliedImagePath = null,

--- a/WondayWall/Models/NewsTopicItem.cs
+++ b/WondayWall/Models/NewsTopicItem.cs
@@ -4,5 +4,5 @@ public record NewsTopicItem(
     string Title,
     string? Summary = null,
     string? Url = null,
-    DateTimeOffset? PublishedAt = null,
+    DateTime? PublishedAt = null,
     string? OgpImageUrl = null);

--- a/WondayWall/Services/ContextService.cs
+++ b/WondayWall/Services/ContextService.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
+using System.Globalization;
 using System.Text;
 using System.ServiceModel.Syndication;
 using System.Xml;
@@ -116,15 +117,17 @@ public class ContextService(AppConfigService configService, IHttpClientFactory h
 
             foreach (var ev in result.Items)
             {
-                var start = ev.Start?.DateTimeDateTimeOffset
-                            ?? (ev.Start?.Date != null
-                                ? DateTimeOffset.Parse(ev.Start.Date)
-                                : DateTimeOffset.UtcNow);
+                var start = ev.Start?.DateTimeDateTimeOffset is { } startDateTimeOffset
+                    ? startDateTimeOffset.LocalDateTime
+                    : ev.Start?.Date != null
+                        ? DateTime.Parse(ev.Start.Date, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal)
+                        : DateTime.Now;
 
-                var endTime = ev.End?.DateTimeDateTimeOffset
-                           ?? (ev.End?.Date != null
-                               ? DateTimeOffset.Parse(ev.End.Date)
-                               : (DateTimeOffset?)null);
+                var endTime = ev.End?.DateTimeDateTimeOffset is { } endDateTimeOffset
+                    ? endDateTimeOffset.LocalDateTime
+                    : ev.End?.Date != null
+                        ? DateTime.Parse(ev.End.Date, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal)
+                        : (DateTime?)null;
 
                 yield return new CalendarEventItem(
                     Title: ev.Summary ?? "(no title)",
@@ -198,7 +201,7 @@ public class ContextService(AppConfigService configService, IHttpClientFactory h
             .ToList();
         var allResults = await Task.WhenAll(fetchTasks);
 
-        var weekAgo = DateTimeOffset.UtcNow.AddDays(-7);
+        var weekAgo = DateTime.Now.AddDays(-7);
 
         // 公開日時の新しい順にソート
         var sortedRawItems = allResults
@@ -240,7 +243,7 @@ public class ContextService(AppConfigService configService, IHttpClientFactory h
         }
     }
 
-    private record RssItem(string Title, string? Summary, string? Url, DateTimeOffset PublishedAt);
+    private record RssItem(string Title, string? Summary, string? Url, DateTime PublishedAt);
 
     /// <summary>1つのRSSソースから7日フィルター済みの生アイテムを返す（OGPなし）</summary>
     private async Task<IReadOnlyList<RssItem>> FetchFromRssSourceAsync(string rssUrl, CancellationToken ct)
@@ -263,7 +266,7 @@ public class ContextService(AppConfigService configService, IHttpClientFactory h
                 item.Title?.Text ?? string.Empty,
                 item.Summary?.Text == "None" ? null : item.Summary?.Text,
                 item.Links.FirstOrDefault()?.Uri.ToString(),
-                item.PublishDate))
+                item.PublishDate.LocalDateTime))
             .ToList();
     }
 
@@ -283,11 +286,11 @@ public class ContextService(AppConfigService configService, IHttpClientFactory h
             .ToListAsync(ct)
             .ConfigureAwait(false);
 
-        var today = DateTimeOffset.Now.Date;
+        var today = DateTime.Today;
         var tomorrow = today.AddDays(1);
 
         // 前日イベント判定: 明日開始するイベントがあれば、そのイベントのみ対象にしてニュースを除外する
-        var tomorrowEvents = events.Where(e => e.StartTime.LocalDateTime.Date == tomorrow).ToList();
+        var tomorrowEvents = events.Where(e => e.StartTime.Date == tomorrow).ToList();
         var filteredEvents = tomorrowEvents.Count > 0 ? tomorrowEvents : events;
         var filteredNews = tomorrowEvents.Count > 0 ? [] : news;
 
@@ -295,7 +298,7 @@ public class ContextService(AppConfigService configService, IHttpClientFactory h
         var context = new PromptContext(
             EventSummary: string.Join("\n", filteredEvents.Select(e =>
             {
-                var daysUntil = (e.StartTime.LocalDateTime.Date - today).Days;
+                var daysUntil = (e.StartTime.Date - today).Days;
                 var proximityTag = daysUntil <= 0 ? "today" : daysUntil == 1 ? "tomorrow" : $"in {daysUntil} days";
                 var line = $"- {e.Title} [{proximityTag}] ({e.StartTime:yyyy/MM/dd HH:mm})" +
                            (string.IsNullOrEmpty(e.Location) ? "" : $" @ {e.Location}");

--- a/WondayWall/Services/GenerationCoordinator.cs
+++ b/WondayWall/Services/GenerationCoordinator.cs
@@ -29,10 +29,10 @@ public class GenerationCoordinator(
 
     public Task<HistoryItem?> RunScheduledAsync(
         bool skipIfNoChanges = false,
-        DateTimeOffset? now = null,
+        DateTime? now = null,
         CancellationToken ct = default)
     {
-        var effectiveNow = now ?? DateTimeOffset.Now;
+        var effectiveNow = now ?? DateTime.Now;
         return ExecuteWithGenerationMutexAsync(async () =>
         {
             var scheduledSlot = GetPendingScheduledSlot(effectiveNow, LoadHistory());
@@ -41,7 +41,7 @@ public class GenerationCoordinator(
 
             logger.LogInformation(
                 "Starting scheduled wallpaper generation for slot {ScheduledSlot:yyyy/MM/dd HH:mm}.",
-                scheduledSlot.Value.ToLocalTime());
+                scheduledSlot.Value);
 
             return await RunCoreAsync(skipIfNoChanges, ct);
         }, ct);
@@ -96,7 +96,7 @@ public class GenerationCoordinator(
 
         var historyItems = LoadHistory();
         var historyItem = new HistoryItem(
-            ExecutedAt: DateTimeOffset.UtcNow,
+            ExecutedAt: DateTime.Now,
             IsSuccess: isSuccess,
             ErrorSummary: errorSummary,
             AppliedImagePath: appliedImagePath,
@@ -149,7 +149,7 @@ public class GenerationCoordinator(
                 }
             }, ct);
 
-    private static DateTimeOffset? GetPendingScheduledSlot(DateTimeOffset now, List<HistoryItem> history)
+    private static DateTime? GetPendingScheduledSlot(DateTime now, List<HistoryItem> history)
     {
         var latestSlot = GetLatestScheduledSlotAtOrBefore(now);
         var lastCompletedRunAt = history
@@ -164,10 +164,10 @@ public class GenerationCoordinator(
         return latestSlot;
     }
 
-    private static DateTimeOffset GetLatestScheduledSlotAtOrBefore(DateTimeOffset now)
+    private static DateTime GetLatestScheduledSlotAtOrBefore(DateTime now)
     {
-        var localNow = now.ToLocalTime();
-        var dayStart = new DateTimeOffset(localNow.Year, localNow.Month, localNow.Day, 0, 0, 0, localNow.Offset);
+        var localNow = now;
+        var dayStart = localNow.Date;
 
         for (var i = ScheduledSlotOffsets.Length - 1; i >= 0; i--)
         {

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -93,7 +93,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
 
         return new GeneratedImageInfo(
             FilePath: filePath,
-            GeneratedAt: DateTimeOffset.UtcNow,
+            GeneratedAt: DateTime.Now,
             UsedPrompt: imagePrompt,
             SourceContext: context);
     }

--- a/WondayWall/Utils/FileNameHelper.cs
+++ b/WondayWall/Utils/FileNameHelper.cs
@@ -6,7 +6,7 @@ public static class FileNameHelper
 {
     public static string GenerateImageFileName(string prefix = "wallpaper", string extension = "png")
     {
-        var timestamp = DateTimeOffset.Now.ToString("yyyyMMdd_HHmmss");
+        var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
         return $"{prefix}_{timestamp}.{extension}";
     }
 


### PR DESCRIPTION
## 概要
- issue #33 に対応し、アプリ内部の日時型を `DateTime` に統一しました
- ライブラリが `DateTimeOffset` を返す箇所は `ContextService` で即座に `DateTime` へ変換するようにしました

## 変更内容
- `CalendarEventItem`、`NewsTopicItem`、`HistoryItem`、`GeneratedImageInfo` の日時プロパティを `DateTime` / `DateTime?` に変更
- `GenerationCoordinator` と CLI のスケジュール判定を `DateTime.Now` ベースに統一
- Google Calendar と RSS の取得結果は `ContextService` でローカル時刻の `DateTime` に変換
- 生成ファイル名と生成時刻の記録も `DateTime` へ統一

## 変更理由
- 外部ライブラリ都合の `DateTimeOffset` がアプリ全体へ伝播しており、内部の日時表現が一貫していませんでした
- 境界で型変換を完了させることで、アプリ内部では単一の日時型で扱えるようにしています

## 確認
- `dotnet build WondayWall.sln`