### PR TITLE
[codex] 1日当たりの更新回数を指定できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 5. 興味キーワードと RSS フィード URL を登録
 6. 「今すぐ生成」で動作確認
 
-定期実行するには、**タスクスケジューラ** に下記コマンドを登録します。
+定期実行するには、アプリの設定画面で **1日あたりの更新回数** を選び、**タスクスケジューラ** に下記コマンドを登録します。
 
 ```
 WondayWall.exe run-once
@@ -41,7 +41,7 @@ WondayWall.exe run-once
 ## CLI コマンド
 
 ```powershell
-WondayWall.exe run-once          # 現在の定刻枠が未処理なら1回生成して終了（タスクスケジューラ向け）
+WondayWall.exe run-once          # 設定した更新回数に応じた現在の定刻枠が未処理なら1回生成して終了（タスクスケジューラ向け）
 WondayWall.exe generate          # 即時生成
 WondayWall.exe check-calendar    # カレンダー取得のみ確認
 WondayWall.exe check-news        # ニュース取得のみ確認
@@ -56,6 +56,13 @@ WondayWall.exe check-google-ai   # Gemini API 接続確認
 | 生成履歴 | `%AppData%\WondayWall\history.json` |
 | 生成画像 | `%AppData%\WondayWall\images\` |
 | OAuth トークン | `%AppData%\WondayWall\calendar-token\` |
+
+## スケジュール
+
+- 1日あたりの更新回数は `1 / 2 / 3 / 4 / 6 / 8 / 12 / 24` 回から選択できます
+- 実行時刻は 24 時間を等分した固定時刻になります
+- 例: `1回` は `0:00`、`2回` は `0:00 / 12:00`、`4回` は `0:00 / 6:00 / 12:00 / 18:00`
+- 定刻を逃した場合だけ、次回ログオン時に `run-once` が未処理枠を補完実行します
 
 ## 開発者向け
 

--- a/WondayWall/Models/AppConfig.cs
+++ b/WondayWall/Models/AppConfig.cs
@@ -6,6 +6,8 @@ public class AppConfig
     public List<string> TargetCalendarIds { get; set; } = [];
     public List<string> RssSources { get; set; } = [];
     public string UserPrompt { get; set; } = string.Empty;
+    /// <summary>1日あたりの自動更新回数</summary>
+    public int RunsPerDay { get; set; } = 4;
     /// <summary>タスクスケジューラ実行時、変化がなければ生成をスキップする</summary>
     public bool SkipGenerationWhenNoChanges { get; set; } = false;
     /// <summary>デスクトップ壁紙に加えてロック画面も更新する</summary>

--- a/WondayWall/Services/GenerationCoordinator.cs
+++ b/WondayWall/Services/GenerationCoordinator.cs
@@ -14,14 +14,6 @@ public class GenerationCoordinator(
 {
     private const string GenerationMutexName = @"Local\WondayWall.Generation";
     private static readonly TimeSpan GenerationMutexWaitInterval = TimeSpan.FromMilliseconds(250);
-    private static readonly TimeSpan[] ScheduledSlotOffsets =
-    [
-        TimeSpan.Zero,
-        TimeSpan.FromHours(6),
-        TimeSpan.FromHours(12),
-        TimeSpan.FromHours(18),
-    ];
-
     private static readonly string HistoryFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "WondayWall", "history.json");
 
     public Task<HistoryItem> RunAsync(bool skipIfNoChanges = false, CancellationToken ct = default)
@@ -33,14 +25,17 @@ public class GenerationCoordinator(
         CancellationToken ct = default)
     {
         var effectiveNow = now ?? DateTimeOffset.Now;
+        var runsPerDay = ScheduleHelper.NormalizeRunsPerDay(appConfigService.Current.RunsPerDay);
+
         return ExecuteWithGenerationMutexAsync(async () =>
         {
-            var scheduledSlot = GetPendingScheduledSlot(effectiveNow, LoadHistory());
+            var scheduledSlot = GetPendingScheduledSlot(effectiveNow, LoadHistory(), runsPerDay);
             if (scheduledSlot is null)
                 return null;
 
             logger.LogInformation(
-                "Starting scheduled wallpaper generation for slot {ScheduledSlot:yyyy/MM/dd HH:mm}.",
+                "{RunsPerDay}回/日スケジュールの枠 {ScheduledSlot:yyyy/MM/dd HH:mm} の壁紙生成を開始します。",
+                runsPerDay,
                 scheduledSlot.Value.ToLocalTime());
 
             return await RunCoreAsync(skipIfNoChanges, ct);
@@ -117,7 +112,7 @@ public class GenerationCoordinator(
         return historyItem;
     }
 
-    // GUI and CLI can launch generation in different processes, so guard it with an OS-wide mutex.
+    // GUI と CLI が別プロセスで同時起動し得るため、OS 全体で共有する Mutex で直列化する。
     private static Task<T> ExecuteWithGenerationMutexAsync<T>(Func<Task<T>> action, CancellationToken ct)
         => Task.Run(async () =>
             {
@@ -149,9 +144,9 @@ public class GenerationCoordinator(
                 }
             }, ct);
 
-    private static DateTimeOffset? GetPendingScheduledSlot(DateTimeOffset now, List<HistoryItem> history)
+    private static DateTimeOffset? GetPendingScheduledSlot(DateTimeOffset now, List<HistoryItem> history, int runsPerDay)
     {
-        var latestSlot = GetLatestScheduledSlotAtOrBefore(now);
+        var latestSlot = ScheduleHelper.GetLatestScheduledSlotAtOrBefore(now, runsPerDay);
         var lastCompletedRunAt = history
             .Where(h => h.IsSuccess)
             .Select(h => h.ExecutedAt)
@@ -162,21 +157,6 @@ public class GenerationCoordinator(
             return null;
 
         return latestSlot;
-    }
-
-    private static DateTimeOffset GetLatestScheduledSlotAtOrBefore(DateTimeOffset now)
-    {
-        var localNow = now.ToLocalTime();
-        var dayStart = new DateTimeOffset(localNow.Year, localNow.Month, localNow.Day, 0, 0, 0, localNow.Offset);
-
-        for (var i = ScheduledSlotOffsets.Length - 1; i >= 0; i--)
-        {
-            var candidate = dayStart + ScheduledSlotOffsets[i];
-            if (candidate <= localNow)
-                return candidate;
-        }
-
-        return dayStart.AddDays(-1) + ScheduledSlotOffsets[^1];
     }
 
     /// <summary>

--- a/WondayWall/Services/TaskSchedulerService.cs
+++ b/WondayWall/Services/TaskSchedulerService.cs
@@ -1,9 +1,10 @@
 using Microsoft.Win32.TaskScheduler;
 using System.Security.Principal;
+using WondayWall.Utils;
 
 namespace WondayWall.Services;
 
-public class TaskSchedulerService
+public class TaskSchedulerService(AppConfigService appConfigService)
 {
     private const string TaskName = "WondayWall";
 
@@ -15,17 +16,22 @@ public class TaskSchedulerService
 
     public void Enable()
     {
+        var runsPerDay = ScheduleHelper.NormalizeRunsPerDay(appConfigService.Current.RunsPerDay);
+
         using var ts = new TaskService();
         var td = ts.NewTask();
-        td.RegistrationInfo.Description = "WondayWall 壁紙自動生成 (0:00 / 6:00 / 12:00 / 18:00 + ログオン時補完)";
+        td.RegistrationInfo.Description = $"WondayWall 壁紙自動生成 ({ScheduleHelper.FormatSlotTimes(runsPerDay)} + ログオン時補完)";
 
         var dailyTrigger = new DailyTrigger
         {
             StartBoundary = DateTime.Today,
             DaysInterval = 1,
         };
-        dailyTrigger.Repetition.Interval = TimeSpan.FromHours(6);
-        dailyTrigger.Repetition.Duration = TimeSpan.FromDays(1);
+        if (runsPerDay > 1)
+        {
+            dailyTrigger.Repetition.Interval = ScheduleHelper.GetInterval(runsPerDay);
+            dailyTrigger.Repetition.Duration = TimeSpan.FromDays(1);
+        }
 
         using var identity = WindowsIdentity.GetCurrent();
         var logonTrigger = new LogonTrigger

--- a/WondayWall/Utils/ScheduleHelper.cs
+++ b/WondayWall/Utils/ScheduleHelper.cs
@@ -1,0 +1,52 @@
+namespace WondayWall.Utils;
+
+public static class ScheduleHelper
+{
+    public const int DefaultRunsPerDay = 4;
+
+    public static IReadOnlyList<int> SupportedRunsPerDay { get; } = [1, 2, 3, 4, 6, 8, 12, 24];
+
+    public static int NormalizeRunsPerDay(int runsPerDay)
+        => SupportedRunsPerDay.Contains(runsPerDay)
+            ? runsPerDay
+            : DefaultRunsPerDay;
+
+    public static TimeSpan GetInterval(int runsPerDay)
+        => TimeSpan.FromHours(24 / NormalizeRunsPerDay(runsPerDay));
+
+    public static IReadOnlyList<TimeSpan> GetSlotOffsets(int runsPerDay)
+    {
+        var normalizedRunsPerDay = NormalizeRunsPerDay(runsPerDay);
+        var intervalHours = 24 / normalizedRunsPerDay;
+
+        return Enumerable
+            .Range(0, normalizedRunsPerDay)
+            .Select(index => TimeSpan.FromHours(intervalHours * index))
+            .ToArray();
+    }
+
+    public static DateTimeOffset GetLatestScheduledSlotAtOrBefore(DateTimeOffset now, int runsPerDay)
+    {
+        var localNow = now.ToLocalTime();
+        var dayStart = new DateTimeOffset(localNow.Year, localNow.Month, localNow.Day, 0, 0, 0, localNow.Offset);
+        var slotOffsets = GetSlotOffsets(runsPerDay);
+
+        for (var i = slotOffsets.Count - 1; i >= 0; i--)
+        {
+            var candidate = dayStart + slotOffsets[i];
+            if (candidate <= localNow)
+                return candidate;
+        }
+
+        return dayStart.AddDays(-1) + slotOffsets[^1];
+    }
+
+    public static string FormatSlotTimes(int runsPerDay)
+        => string.Join(
+            " / ",
+            GetSlotOffsets(runsPerDay)
+                .Select(static offset => $"{(int)offset.TotalHours}:00"));
+
+    public static string FormatScheduleDescription(int runsPerDay)
+        => $"毎日 {FormatSlotTimes(runsPerDay)} に実行します。PC の電源断などで定刻を逃した場合だけ、次回ログオン時に補完実行します。";
+}

--- a/WondayWall/ViewModels/MainWindowViewModel.cs
+++ b/WondayWall/ViewModels/MainWindowViewModel.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.Logging;
 using WondayWall.Models;
 using WondayWall.Services;
+using WondayWall.Utils;
 
 namespace WondayWall.ViewModels;
 
@@ -36,6 +37,9 @@ public partial class MainWindowViewModel : ObservableObject
     public partial bool IsTaskSchedulerEnabled { get; set; }
 
     [ObservableProperty]
+    public partial int SelectedRunsPerDay { get; set; }
+
+    [ObservableProperty]
     public partial GeneratedImageInfo? LastGeneratedImage { get; set; }
 
     [ObservableProperty]
@@ -51,6 +55,8 @@ public partial class MainWindowViewModel : ObservableObject
     public ObservableCollection<HistoryItem> History { get; } = [];
     public ObservableCollection<string> RssSources { get; } = [];
     public ObservableCollection<AvailableCalendar> AvailableCalendars { get; } = [];
+    public IReadOnlyList<int> AvailableRunsPerDayOptions => ScheduleHelper.SupportedRunsPerDay;
+    public string TaskSchedulerScheduleDescription => ScheduleHelper.FormatScheduleDescription(SelectedRunsPerDay);
 
     public MainWindowViewModel(
         AppConfigService configService,
@@ -66,6 +72,7 @@ public partial class MainWindowViewModel : ObservableObject
         _logger = logger;
 
         AppConfig = configService.Load();
+        SelectedRunsPerDay = ScheduleHelper.NormalizeRunsPerDay(AppConfig.RunsPerDay);
         foreach (var src in AppConfig.RssSources)
             RssSources.Add(src);
         IsTaskSchedulerEnabled = _taskSchedulerService.IsEnabled();
@@ -139,6 +146,7 @@ public partial class MainWindowViewModel : ObservableObject
     [RelayCommand]
     private void Save()
     {
+        AppConfig.RunsPerDay = ScheduleHelper.NormalizeRunsPerDay(SelectedRunsPerDay);
         AppConfig.RssSources = [.. RssSources];
         if (AvailableCalendars.Count > 0)
         {
@@ -278,5 +286,18 @@ public partial class MainWindowViewModel : ObservableObject
         History.Clear();
         foreach (var item in items)
             History.Add(item);
+    }
+
+    partial void OnSelectedRunsPerDayChanged(int value)
+    {
+        var normalizedRunsPerDay = ScheduleHelper.NormalizeRunsPerDay(value);
+        if (value != normalizedRunsPerDay)
+        {
+            SelectedRunsPerDay = normalizedRunsPerDay;
+            return;
+        }
+
+        AppConfig.RunsPerDay = normalizedRunsPerDay;
+        OnPropertyChanged(nameof(TaskSchedulerScheduleDescription));
     }
 }

--- a/WondayWall/Views/MainWindow.xaml
+++ b/WondayWall/Views/MainWindow.xaml
@@ -383,10 +383,26 @@
                                                 Command="{Binding ToggleTaskSchedulerCommand}"
                                                 Content="固定時刻スケジュールを有効にする"
                                                 IsChecked="{Binding IsTaskSchedulerEnabled}" />
+                                            <StackPanel Margin="24,8,0,0">
+                                                <TextBlock
+                                                    Margin="0,0,0,4"
+                                                    FontWeight="SemiBold"
+                                                    Text="1日あたりの更新回数" />
+                                                <ComboBox
+                                                    Width="120"
+                                                    ItemsSource="{Binding AvailableRunsPerDayOptions}"
+                                                    SelectedItem="{Binding SelectedRunsPerDay, UpdateSourceTrigger=PropertyChanged}">
+                                                    <ComboBox.ItemTemplate>
+                                                        <DataTemplate>
+                                                            <TextBlock Text="{Binding StringFormat={}{0}回}" />
+                                                        </DataTemplate>
+                                                    </ComboBox.ItemTemplate>
+                                                </ComboBox>
+                                            </StackPanel>
                                             <TextBlock
                                                 Width="320"
-                                                Margin="24,4,0,0"
-                                                Text="毎日 0:00 / 6:00 / 12:00 / 18:00 に実行します。PC の電源断などで定刻を逃した場合だけ、次回ログオン時に補完実行します。"
+                                                Margin="24,8,0,0"
+                                                Text="{Binding TaskSchedulerScheduleDescription}"
                                                 TextWrapping="Wrap" />
                                         </StackPanel>
                                     </ui:CardControl>


### PR DESCRIPTION
## 概要
- 1日あたりの更新回数を設定できるようにしました
- 更新回数に応じて固定時刻スケジュールと `run-once` の定刻枠判定が連動するようにしました
- 設定UIと README を新仕様に合わせて更新しました

## 変更内容
- `AppConfig` に `RunsPerDay` を追加
- `ScheduleHelper` を追加し、対応回数 `1 / 2 / 3 / 4 / 6 / 8 / 12 / 24` 回と各定刻の計算を共通化
- `TaskSchedulerService` を更新し、設定した回数に応じて Task Scheduler の説明文と繰り返し間隔を構成
- `GenerationCoordinator` を更新し、`run-once` が設定した回数に応じた最新定刻枠を使って未処理判定するように変更
- 設定画面に更新回数の選択 UI と、選択値に応じたスケジュール説明文を追加
- README にスケジュール仕様を追記

## 確認
- `dotnet restore WondayWall\WondayWall.csproj`
- `dotnet build WondayWall\WondayWall.csproj --no-restore`

Closes #32