### PR TITLE
[codex] issue #34 候補コンテキストの採用判定をプロンプト生成段に移す

### DIFF
--- a/WondayWall/Commands/CliCommands.cs
+++ b/WondayWall/Commands/CliCommands.cs
@@ -60,7 +60,25 @@ public class CliCommands(
     public async Task CheckGoogleAiAsync(CancellationToken cancellationToken = default)
     {
         logger.LogInformation("Testing Google AI connection...");
-        var info = await googleAiService.GenerateWallpaperAsync(new("Test event", "Test news", "1920x1080"), cancellationToken);
+        var info = await googleAiService.GenerateWallpaperAsync(
+            new(
+                CalendarEvents:
+                [
+                    new PromptCalendarEvent(
+                        Id: "event-1",
+                        Title: "Sample trip",
+                        ProximityTag: "tomorrow",
+                        StartTime: DateTimeOffset.Now.AddDays(1))
+                ],
+                NewsTopics:
+                [
+                    new PromptNewsTopic(
+                        Id: "news-1",
+                        Title: "Sample news topic",
+                        Summary: "Sample news summary")
+                ],
+                ImageSize: "1920x1080"),
+            cancellationToken);
         logger.LogInformation("Success! Image saved to: {Path}", info.FilePath);
     }
 

--- a/WondayWall/Models/PromptContext.cs
+++ b/WondayWall/Models/PromptContext.cs
@@ -1,9 +1,25 @@
 namespace WondayWall.Models;
 
 public record PromptContext(
-    string EventSummary = "",
-    string NewsSummary = "",
+    IReadOnlyList<PromptCalendarEvent>? CalendarEvents = null,
+    IReadOnlyList<PromptNewsTopic>? NewsTopics = null,
     string ImageSize = "1920x1080",
     string AspectRatio = "16:9",
-    string? AdditionalConstraints = null,
-    IReadOnlyList<string>? OgpImageUrls = null);
+    string? AdditionalConstraints = null);
+
+public record PromptCalendarEvent(
+    string Id,
+    string Title,
+    string ProximityTag,
+    DateTimeOffset StartTime,
+    DateTimeOffset? EndTime = null,
+    string? Location = null,
+    string? Description = null);
+
+public record PromptNewsTopic(
+    string Id,
+    string Title,
+    string? Summary = null,
+    string? Url = null,
+    DateTimeOffset? PublishedAt = null,
+    string? OgpImageUrl = null);

--- a/WondayWall/Services/ContextService.cs
+++ b/WondayWall/Services/ContextService.cs
@@ -284,37 +284,39 @@ public class ContextService(AppConfigService configService, IHttpClientFactory h
             .ConfigureAwait(false);
 
         var today = DateTimeOffset.Now.Date;
-        var tomorrow = today.AddDays(1);
-
-        // 前日イベント判定: 明日開始するイベントがあれば、そのイベントのみ対象にしてニュースを除外する
-        var tomorrowEvents = events.Where(e => e.StartTime.LocalDateTime.Date == tomorrow).ToList();
-        var filteredEvents = tomorrowEvents.Count > 0 ? tomorrowEvents : events;
-        var filteredNews = tomorrowEvents.Count > 0 ? [] : news;
 
         var displayInfo = DisplayHelper.GetDisplayInfo();
         var context = new PromptContext(
-            EventSummary: string.Join("\n", filteredEvents.Select(e =>
-            {
-                var daysUntil = (e.StartTime.LocalDateTime.Date - today).Days;
-                var proximityTag = daysUntil <= 0 ? "today" : daysUntil == 1 ? "tomorrow" : $"in {daysUntil} days";
-                var line = $"- {e.Title} [{proximityTag}] ({e.StartTime:yyyy/MM/dd HH:mm})" +
-                           (string.IsNullOrEmpty(e.Location) ? "" : $" @ {e.Location}");
-                return string.IsNullOrEmpty(e.Description)
-                    ? line
-                    : $"{line}\n  {e.Description}";
-            })),
-            NewsSummary: string.Join("\n", filteredNews.Select(n => string.IsNullOrEmpty(n.Summary) ? $"- {n.Title}" : $"- {n.Title}\n  {n.Summary}")),
+            CalendarEvents: events.Select((eventItem, index) => new PromptCalendarEvent(
+                Id: $"event-{index + 1}",
+                Title: eventItem.Title,
+                ProximityTag: GetProximityTag(eventItem.StartTime, today),
+                StartTime: eventItem.StartTime,
+                EndTime: eventItem.EndTime,
+                Location: eventItem.Location,
+                Description: eventItem.Description))
+                .ToList(),
+            NewsTopics: news.Select((newsItem, index) => new PromptNewsTopic(
+                Id: $"news-{index + 1}",
+                Title: newsItem.Title,
+                Summary: newsItem.Summary,
+                Url: newsItem.Url,
+                PublishedAt: newsItem.PublishedAt,
+                OgpImageUrl: newsItem.OgpImageUrl))
+                .ToList(),
             ImageSize: displayInfo.Size,
             AspectRatio: displayInfo.AspectRatio,
             AdditionalConstraints: string.IsNullOrWhiteSpace(config.UserPrompt)
                 ? null
-                : config.UserPrompt,
-            OgpImageUrls: filteredNews.Where(n => n.OgpImageUrl != null)
-                              .Select(n => n.OgpImageUrl!)
-                              .Take(3)
-                              .ToList());
+                : config.UserPrompt);
 
-        return new ContextBuildResult(context, filteredEvents, filteredNews);
+        return new ContextBuildResult(context, events, news);
+    }
+
+    private static string GetProximityTag(DateTimeOffset startTime, DateTime today)
+    {
+        var daysUntil = (startTime.LocalDateTime.Date - today).Days;
+        return daysUntil <= 0 ? "today" : daysUntil == 1 ? "tomorrow" : $"in {daysUntil} days";
     }
 
     private async Task<CalendarService> GetCalendarServiceAsync(CancellationToken ct = default)

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -21,6 +21,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         PropertyNameCaseInsensitive = true,
         WriteIndented = true,
     };
+    private static readonly Schema PromptSelectionResponseSchema = CreatePromptSelectionResponseSchema();
 
     public async Task<GeneratedImageInfo> GenerateWallpaperAsync(
         PromptContext context,
@@ -37,14 +38,19 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
             UseGoogleSearch = true,
         };
         var contextPrompt = BuildTextModelPrompt(context);
-        var promptResponse = await textModel.GenerateContentAsync(contextPrompt, cancellationToken: ct);
-        var promptSelection = ParsePromptSelection(promptResponse.Text(), context);
-        if (!promptSelection.IsStructuredResponse)
+        var promptRequest = new GenerateContentRequest
         {
-            logger.LogWarning("テキストモデル応答が想定JSONではなかったため、生テキストを画像プロンプトとして扱います");
-        }
+            GenerationConfig = new GenerationConfig
+            {
+                ResponseMimeType = "application/json",
+                ResponseSchema = PromptSelectionResponseSchema,
+            },
+        };
+        promptRequest.AddText(contextPrompt);
 
-        var imagePrompt = promptSelection.ImagePrompt;
+        var promptResponse = await textModel.GenerateContentAsync(promptRequest, cancellationToken: ct);
+        var promptSelection = ParsePromptSelection(promptResponse.Text());
+        var imagePrompt = promptSelection.ImagePrompt.Trim();
 
         // ステップ2: 画像モデルでアスペクト比・サイズを指定して壁紙を生成
         var displayInfo = DisplayHelper.GetDisplayInfo();
@@ -154,16 +160,10 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
             - If the nearest event is NEGATIVE or NEUTRAL, ignore it and continue considering later positive events
               and news topics as potential primary themes.
 
-            Return valid JSON only with this exact shape:
-            {
-              "imagePrompt": "A detailed English image-generation prompt",
-              "selectedNewsIds": ["news-1", "news-2"]
-            }
-
-            JSON rules:
-            - imagePrompt: a single detailed English prompt for the image model.
-            - selectedNewsIds: only ids of news topics that materially influenced imagePrompt.
-            - If no news topic is used, return an empty array.
+            Return a response that matches the configured JSON schema.
+            - imagePrompt must be a single detailed English prompt for the image model.
+            - selectedNewsIds must contain only ids of news topics that materially influenced imagePrompt.
+            - If no news topic is used, selectedNewsIds must be an empty array.
             - Do not output markdown fences or any extra explanation.
             """,
         };
@@ -189,104 +189,32 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
     private static string SerializeCandidates<T>(IReadOnlyList<T>? items)
         => JsonSerializer.Serialize(items ?? Array.Empty<T>(), JsonSerializerOptions);
 
-    private static PromptSelectionResult ParsePromptSelection(string? responseText, PromptContext context)
+    private static Schema CreatePromptSelectionResponseSchema()
+        => GoogleSchemaHelper.ConvertToSchema<PromptSelectionResponse>(JsonSerializerOptions);
+
+    private static PromptSelectionResponse ParsePromptSelection(string? responseText)
     {
-        if (TryParsePromptSelectionResponse(responseText, out var parsedResponse))
-        {
-            return new PromptSelectionResult(
-                ImagePrompt: parsedResponse!.ImagePrompt!.Trim(),
-                SelectedNewsIds: (parsedResponse.SelectedNewsIds ?? [])
-                    .Where(id => !string.IsNullOrWhiteSpace(id))
-                    .Select(id => id.Trim())
-                    .Distinct(StringComparer.Ordinal)
-                    .ToList(),
-                IsStructuredResponse: true);
-        }
-
-        var fallbackPrompt = !string.IsNullOrWhiteSpace(responseText)
-            ? responseText.Trim()
-            : BuildFallbackImagePrompt(context);
-
-        return new PromptSelectionResult(fallbackPrompt, [], false);
-    }
-
-    private static bool TryParsePromptSelectionResponse(string? responseText, out PromptSelectionResponse? response)
-    {
-        response = null;
-
         if (string.IsNullOrWhiteSpace(responseText))
-            return false;
-
-        var jsonText = ExtractJsonObject(responseText);
-        if (string.IsNullOrWhiteSpace(jsonText))
-            return false;
+            throw new InvalidOperationException("Google AI did not return a structured prompt response.");
 
         try
         {
-            response = JsonSerializer.Deserialize<PromptSelectionResponse>(jsonText, JsonSerializerOptions);
-            return !string.IsNullOrWhiteSpace(response?.ImagePrompt);
+            var response = JsonSerializer.Deserialize<PromptSelectionResponse>(responseText, JsonSerializerOptions);
+            if (response == null || string.IsNullOrWhiteSpace(response.ImagePrompt))
+                throw new InvalidOperationException("Google AI returned a prompt response without imagePrompt.");
+
+            response.SelectedNewsIds = (response.SelectedNewsIds ?? [])
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Select(id => id.Trim())
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+
+            return response;
         }
-        catch (JsonException)
+        catch (JsonException ex)
         {
-            response = null;
-            return false;
+            throw new InvalidOperationException("Failed to parse Google AI structured prompt response.", ex);
         }
-    }
-
-    private static string? ExtractJsonObject(string responseText)
-    {
-        var trimmed = responseText.Trim();
-        var startIndex = trimmed.IndexOf('{');
-        var endIndex = trimmed.LastIndexOf('}');
-        if (startIndex < 0 || endIndex <= startIndex)
-            return null;
-
-        return trimmed[startIndex..(endIndex + 1)];
-    }
-
-    private static string BuildFallbackImagePrompt(PromptContext context)
-    {
-        var parts = new List<string>
-        {
-            $"Create a beautiful desktop wallpaper at {context.ImageSize} resolution with a {context.AspectRatio} aspect ratio.",
-            "Use the provided calendar events and news topics as inspiration. Favor positive upcoming events, and let relevant news lead when events are not suitable.",
-            "No text, logos, or UI overlays. Wide landscape composition.",
-        };
-
-        if ((context.CalendarEvents ?? []).Count > 0)
-        {
-            parts.Add("Calendar events:\n" + string.Join("\n", context.CalendarEvents!.Select(FormatFallbackEvent)));
-        }
-
-        if ((context.NewsTopics ?? []).Count > 0)
-        {
-            parts.Add("News topics:\n" + string.Join("\n", context.NewsTopics!.Select(FormatFallbackNews)));
-        }
-
-        if (!string.IsNullOrWhiteSpace(context.AdditionalConstraints))
-        {
-            parts.Add($"Additional instructions: {context.AdditionalConstraints}");
-        }
-
-        return string.Join("\n\n", parts);
-    }
-
-    private static string FormatFallbackEvent(PromptCalendarEvent eventItem)
-    {
-        var line = $"- {eventItem.Title} [{eventItem.ProximityTag}] ({eventItem.StartTime:yyyy/MM/dd HH:mm})";
-        if (!string.IsNullOrWhiteSpace(eventItem.Location))
-            line += $" @ {eventItem.Location}";
-        if (!string.IsNullOrWhiteSpace(eventItem.Description))
-            line += $": {eventItem.Description}";
-        return line;
-    }
-
-    private static string FormatFallbackNews(PromptNewsTopic newsTopic)
-    {
-        var line = $"- {newsTopic.Title}";
-        if (!string.IsNullOrWhiteSpace(newsTopic.Summary))
-            line += $": {newsTopic.Summary}";
-        return line;
     }
 
     private static byte[]? ExtractImageBytes(GenerateContentResponse response)
@@ -307,13 +235,8 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
 
     private sealed class PromptSelectionResponse
     {
-        public string? ImagePrompt { get; init; }
+        public required string ImagePrompt { get; init; }
 
-        public List<string>? SelectedNewsIds { get; init; }
+        public required List<string> SelectedNewsIds { get; set; }
     }
-
-    private sealed record PromptSelectionResult(
-        string ImagePrompt,
-        List<string> SelectedNewsIds,
-        bool IsStructuredResponse);
 }

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Net.Http;
+using System.Text.Json;
 using GenerativeAI;
 using GenerativeAI.Types;
 using Microsoft.Extensions.Logging;
@@ -14,6 +15,15 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
     private static readonly string FixedImageSavePath = Path.Combine(
         System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData),
         "WondayWall", "wallpapers");
+    private static readonly JsonSerializerOptions PromptJsonSerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
+    private static readonly JsonSerializerOptions ResponseJsonSerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
 
     public async Task<GeneratedImageInfo> GenerateWallpaperAsync(
         PromptContext context,
@@ -31,7 +41,13 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         };
         var contextPrompt = BuildTextModelPrompt(context);
         var promptResponse = await textModel.GenerateContentAsync(contextPrompt, cancellationToken: ct);
-        var imagePrompt = promptResponse.Text() ?? contextPrompt;
+        var promptSelection = ParsePromptSelection(promptResponse.Text(), context);
+        if (!promptSelection.IsStructuredResponse)
+        {
+            logger.LogWarning("テキストモデル応答が想定JSONではなかったため、生テキストを画像プロンプトとして扱います");
+        }
+
+        var imagePrompt = promptSelection.ImagePrompt;
 
         // ステップ2: 画像モデルでアスペクト比・サイズを指定して壁紙を生成
         var displayInfo = DisplayHelper.GetDisplayInfo();
@@ -49,10 +65,15 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
             UseGoogleSearch = true,
         };
 
-        // OGP画像がある場合はインラインデータとして添付し、プロンプトにもその旨を付記
-        var ogpUrls = (context.OgpImageUrls ?? []).Take(3).ToList();
+        // テキストモデルが採用したニュースだけ、そのOGP画像を参照画像として添付する
+        var selectedNewsIds = promptSelection.SelectedNewsIds.ToHashSet(StringComparer.Ordinal);
+        var ogpUrls = (context.NewsTopics ?? [])
+            .Where(newsTopic => selectedNewsIds.Contains(newsTopic.Id) && !string.IsNullOrWhiteSpace(newsTopic.OgpImageUrl))
+            .Select(newsTopic => newsTopic.OgpImageUrl!)
+            .Take(3)
+            .ToList();
         var finalPrompt = ogpUrls.Count > 0
-            ? $"{imagePrompt}\n\nReference images from the related news articles are attached. " +
+            ? $"{imagePrompt}\n\nReference images from the selected news topics are attached. " +
               "Incorporate their visual themes, color palette, and subject matter into the wallpaper design."
             : imagePrompt;
 
@@ -100,13 +121,13 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
 
     /// <summary>
     /// テキストモデルへ送るプロンプトを構築する。
-    /// テキストモデルはこのプロンプトを受け取り、画像生成モデル向けの詳細な英語プロンプトを返す。
+    /// テキストモデルは候補コンテキストから採用要素を決め、画像生成用JSONを返す。
     /// </summary>
     private static string BuildTextModelPrompt(PromptContext context)
     {
         var parts = new List<string>
         {
-            $"""
+            $$"""
             You are an expert desktop wallpaper image-generation prompt writer.
             You will be given calendar events, news topics, and optionally reference images from those news articles.
             You MUST aggressively use Google Search before writing the prompt.
@@ -114,36 +135,50 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
             image references, and related background context), then cross-check recency and consistency.
             Prefer fresh, high-signal information and concrete visual details you can translate into imagery.
             Do not rely only on the user's short summaries when searchable context exists.
-            Your task: write a single detailed, creative English prompt for an image generation model
-            ({context.ImageSize} resolution, {context.AspectRatio} aspect ratio) that creates a beautiful desktop wallpaper.
+            Your task: review all candidate calendar events and news topics, decide which ones should materially influence
+            the wallpaper, and then write a single detailed, creative English prompt for an image generation model
+            ({{context.ImageSize}} resolution, {{context.AspectRatio}} aspect ratio) that creates a beautiful desktop wallpaper.
 
-            The wallpaper should visually reflect the themes, mood, and atmosphere of the provided events and news.
-            If reference images are supplied, incorporate their color palette, visual motifs, and subject matter.
+            The wallpaper should visually reflect the themes, mood, and atmosphere of the selected events and news.
+            If reference images are supplied later, they will correspond only to selected news topics.
             Describe visual elements, style, mood, color palette, lighting, and composition in detail.
             No text, logos, or UI overlays. Wide landscape orientation unless aspect ratio specifies otherwise.
-            Output only the English image generation prompt — no explanation or preamble.
 
             For calendar events:
             - Only include POSITIVE events (celebrations, trips, parties, hobbies, achievements, social gatherings, etc.)
               in the visual design. Ignore NEGATIVE or NEUTRAL events (medical appointments, work deadlines,
-              chores, administrative tasks, etc.).
+              chores, administrative tasks, etc.), but do not let them suppress other event or news candidates.
             - Each event has a proximity tag indicating when it occurs. Use it to determine the visual weight:
               [today] or [tomorrow]: this event DOMINATES the entire image — make it the primary subject and theme,
                 occupying nearly all visual elements.
               [in 2-3 days]: this event is a MAJOR visual theme, occupying 50–70% of the image's visual elements.
               [in 4-7 days]: this event is a MINOR accent or background element (15–30% of visual elements).
             - When multiple positive events are present, prioritize the ones happening sooner.
+            - If the nearest event is NEGATIVE or NEUTRAL, ignore it and continue considering later positive events
+              and news topics as potential primary themes.
+
+            Return valid JSON only with this exact shape:
+            {
+              "imagePrompt": "A detailed English image-generation prompt",
+              "selectedNewsIds": ["news-1", "news-2"]
+            }
+
+            JSON rules:
+            - imagePrompt: a single detailed English prompt for the image model.
+            - selectedNewsIds: only ids of news topics that materially influenced imagePrompt.
+            - If no news topic is used, return an empty array.
+            - Do not output markdown fences or any extra explanation.
             """,
         };
 
-        if (!string.IsNullOrWhiteSpace(context.EventSummary))
+        if ((context.CalendarEvents ?? []).Count > 0)
         {
-            parts.Add($"Upcoming calendar events:\n{context.EventSummary}");
+            parts.Add($"Calendar event candidates (JSON):\n{SerializeCandidates(context.CalendarEvents)}");
         }
 
-        if (!string.IsNullOrWhiteSpace(context.NewsSummary))
+        if ((context.NewsTopics ?? []).Count > 0)
         {
-            parts.Add($"Current news topics:\n{context.NewsSummary}");
+            parts.Add($"News topic candidates (JSON):\n{SerializeCandidates(context.NewsTopics)}");
         }
 
         if (!string.IsNullOrWhiteSpace(context.AdditionalConstraints))
@@ -152,6 +187,109 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         }
 
         return string.Join("\n\n", parts);
+    }
+
+    private static string SerializeCandidates<T>(IReadOnlyList<T>? items)
+        => JsonSerializer.Serialize(items ?? Array.Empty<T>(), PromptJsonSerializerOptions);
+
+    private static PromptSelectionResult ParsePromptSelection(string? responseText, PromptContext context)
+    {
+        if (TryParsePromptSelectionResponse(responseText, out var parsedResponse))
+        {
+            return new PromptSelectionResult(
+                ImagePrompt: parsedResponse!.ImagePrompt!.Trim(),
+                SelectedNewsIds: (parsedResponse.SelectedNewsIds ?? [])
+                    .Where(id => !string.IsNullOrWhiteSpace(id))
+                    .Select(id => id.Trim())
+                    .Distinct(StringComparer.Ordinal)
+                    .ToList(),
+                IsStructuredResponse: true);
+        }
+
+        var fallbackPrompt = !string.IsNullOrWhiteSpace(responseText)
+            ? responseText.Trim()
+            : BuildFallbackImagePrompt(context);
+
+        return new PromptSelectionResult(fallbackPrompt, [], false);
+    }
+
+    private static bool TryParsePromptSelectionResponse(string? responseText, out PromptSelectionResponse? response)
+    {
+        response = null;
+
+        if (string.IsNullOrWhiteSpace(responseText))
+            return false;
+
+        var jsonText = ExtractJsonObject(responseText);
+        if (string.IsNullOrWhiteSpace(jsonText))
+            return false;
+
+        try
+        {
+            response = JsonSerializer.Deserialize<PromptSelectionResponse>(jsonText, ResponseJsonSerializerOptions);
+            return !string.IsNullOrWhiteSpace(response?.ImagePrompt);
+        }
+        catch (JsonException)
+        {
+            response = null;
+            return false;
+        }
+    }
+
+    private static string? ExtractJsonObject(string responseText)
+    {
+        var trimmed = responseText.Trim();
+        var startIndex = trimmed.IndexOf('{');
+        var endIndex = trimmed.LastIndexOf('}');
+        if (startIndex < 0 || endIndex <= startIndex)
+            return null;
+
+        return trimmed[startIndex..(endIndex + 1)];
+    }
+
+    private static string BuildFallbackImagePrompt(PromptContext context)
+    {
+        var parts = new List<string>
+        {
+            $"Create a beautiful desktop wallpaper at {context.ImageSize} resolution with a {context.AspectRatio} aspect ratio.",
+            "Use the provided calendar events and news topics as inspiration. Favor positive upcoming events, and let relevant news lead when events are not suitable.",
+            "No text, logos, or UI overlays. Wide landscape composition.",
+        };
+
+        if ((context.CalendarEvents ?? []).Count > 0)
+        {
+            parts.Add("Calendar events:\n" + string.Join("\n", context.CalendarEvents!.Select(FormatFallbackEvent)));
+        }
+
+        if ((context.NewsTopics ?? []).Count > 0)
+        {
+            parts.Add("News topics:\n" + string.Join("\n", context.NewsTopics!.Select(FormatFallbackNews)));
+        }
+
+        if (!string.IsNullOrWhiteSpace(context.AdditionalConstraints))
+        {
+            parts.Add($"Additional instructions: {context.AdditionalConstraints}");
+        }
+
+        return string.Join("\n\n", parts);
+    }
+
+    private static string FormatFallbackEvent(PromptCalendarEvent eventItem)
+    {
+        var line = $"- {eventItem.Title} [{eventItem.ProximityTag}] ({eventItem.StartTime:yyyy/MM/dd HH:mm})";
+        if (!string.IsNullOrWhiteSpace(eventItem.Location))
+            line += $" @ {eventItem.Location}";
+        if (!string.IsNullOrWhiteSpace(eventItem.Description))
+            line += $": {eventItem.Description}";
+        return line;
+    }
+
+    private static string FormatFallbackNews(PromptNewsTopic newsTopic)
+    {
+        var line = $"- {newsTopic.Title}";
+        if (!string.IsNullOrWhiteSpace(newsTopic.Summary))
+            line += $": {newsTopic.Summary}";
+        return line;
     }
 
     private static byte[]? ExtractImageBytes(GenerateContentResponse response)
@@ -169,4 +307,16 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         }
         return null;
     }
+
+    private sealed class PromptSelectionResponse
+    {
+        public string? ImagePrompt { get; init; }
+
+        public List<string>? SelectedNewsIds { get; init; }
+    }
+
+    private sealed record PromptSelectionResult(
+        string ImagePrompt,
+        List<string> SelectedNewsIds,
+        bool IsStructuredResponse);
 }

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -21,7 +21,6 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         PropertyNameCaseInsensitive = true,
         WriteIndented = true,
     };
-    private static readonly Schema PromptSelectionResponseSchema = CreatePromptSelectionResponseSchema();
 
     public async Task<GeneratedImageInfo> GenerateWallpaperAsync(
         PromptContext context,
@@ -38,18 +37,19 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
             UseGoogleSearch = true,
         };
         var contextPrompt = BuildTextModelPrompt(context);
-        var promptRequest = new GenerateContentRequest
-        {
-            GenerationConfig = new GenerationConfig
-            {
-                ResponseMimeType = "application/json",
-                ResponseSchema = PromptSelectionResponseSchema,
-            },
-        };
+        var promptRequest = new GenerateContentRequest();
+        promptRequest.UseJsonMode<PromptSelectionResponse>(JsonSerializerOptions);
         promptRequest.AddText(contextPrompt);
 
-        var promptResponse = await textModel.GenerateContentAsync(promptRequest, cancellationToken: ct);
-        var promptSelection = ParsePromptSelection(promptResponse.Text());
+        var promptSelection = await textModel.GenerateObjectAsync<PromptSelectionResponse>(promptRequest, ct);
+        if (promptSelection == null || string.IsNullOrWhiteSpace(promptSelection.ImagePrompt))
+            throw new InvalidOperationException("Google AI returned an invalid structured prompt response.");
+
+        promptSelection.SelectedNewsIds = (promptSelection.SelectedNewsIds ?? [])
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
         var imagePrompt = promptSelection.ImagePrompt.Trim();
 
         // ステップ2: 画像モデルでアスペクト比・サイズを指定して壁紙を生成
@@ -80,7 +80,8 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
               "Incorporate their visual themes, color palette, and subject matter into the wallpaper design."
             : imagePrompt;
 
-        var parts = new List<Part> { new Part(finalPrompt) };
+        var imageRequest = new GenerateContentRequest();
+        imageRequest.AddText(finalPrompt);
         foreach (var imgUrl in ogpUrls)
         {
             try
@@ -90,14 +91,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
                 imgResponse.EnsureSuccessStatusCode();
                 var mimeType = imgResponse.Content.Headers.ContentType?.MediaType ?? "image/jpeg";
                 var imgBytes = await imgResponse.Content.ReadAsByteArrayAsync(ct);
-                parts.Add(new Part
-                {
-                    InlineData = new Blob
-                    {
-                        MimeType = mimeType,
-                        Data = Convert.ToBase64String(imgBytes),
-                    }
-                });
+                imageRequest.AddInlineData(Convert.ToBase64String(imgBytes), mimeType);
             }
             catch (Exception ex)
             {
@@ -105,7 +99,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
             }
         }
 
-        var response = await imageModel.GenerateContentAsync(parts, cancellationToken: ct);
+        var response = await imageModel.GenerateContentAsync(imageRequest, cancellationToken: ct);
 
         var imageBytes = ExtractImageBytes(response);
 
@@ -170,12 +164,12 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
 
         if ((context.CalendarEvents ?? []).Count > 0)
         {
-            parts.Add($"Calendar event candidates (JSON):\n{SerializeCandidates(context.CalendarEvents)}");
+            parts.Add($"Calendar event candidates (JSON):\n{JsonSerializer.Serialize(context.CalendarEvents, JsonSerializerOptions)}");
         }
 
         if ((context.NewsTopics ?? []).Count > 0)
         {
-            parts.Add($"News topic candidates (JSON):\n{SerializeCandidates(context.NewsTopics)}");
+            parts.Add($"News topic candidates (JSON):\n{JsonSerializer.Serialize(context.NewsTopics, JsonSerializerOptions)}");
         }
 
         if (!string.IsNullOrWhiteSpace(context.AdditionalConstraints))
@@ -184,37 +178,6 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         }
 
         return string.Join("\n\n", parts);
-    }
-
-    private static string SerializeCandidates<T>(IReadOnlyList<T>? items)
-        => JsonSerializer.Serialize(items ?? Array.Empty<T>(), JsonSerializerOptions);
-
-    private static Schema CreatePromptSelectionResponseSchema()
-        => GoogleSchemaHelper.ConvertToSchema<PromptSelectionResponse>(JsonSerializerOptions);
-
-    private static PromptSelectionResponse ParsePromptSelection(string? responseText)
-    {
-        if (string.IsNullOrWhiteSpace(responseText))
-            throw new InvalidOperationException("Google AI did not return a structured prompt response.");
-
-        try
-        {
-            var response = JsonSerializer.Deserialize<PromptSelectionResponse>(responseText, JsonSerializerOptions);
-            if (response == null || string.IsNullOrWhiteSpace(response.ImagePrompt))
-                throw new InvalidOperationException("Google AI returned a prompt response without imagePrompt.");
-
-            response.SelectedNewsIds = (response.SelectedNewsIds ?? [])
-                .Where(id => !string.IsNullOrWhiteSpace(id))
-                .Select(id => id.Trim())
-                .Distinct(StringComparer.Ordinal)
-                .ToList();
-
-            return response;
-        }
-        catch (JsonException ex)
-        {
-            throw new InvalidOperationException("Failed to parse Google AI structured prompt response.", ex);
-        }
     }
 
     private static byte[]? ExtractImageBytes(GenerateContentResponse response)

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -15,14 +15,11 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
     private static readonly string FixedImageSavePath = Path.Combine(
         System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData),
         "WondayWall", "wallpapers");
-    private static readonly JsonSerializerOptions PromptJsonSerializerOptions = new()
+    private static readonly JsonSerializerOptions JsonSerializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        WriteIndented = true,
-    };
-    private static readonly JsonSerializerOptions ResponseJsonSerializerOptions = new()
-    {
         PropertyNameCaseInsensitive = true,
+        WriteIndented = true,
     };
 
     public async Task<GeneratedImageInfo> GenerateWallpaperAsync(
@@ -190,7 +187,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
     }
 
     private static string SerializeCandidates<T>(IReadOnlyList<T>? items)
-        => JsonSerializer.Serialize(items ?? Array.Empty<T>(), PromptJsonSerializerOptions);
+        => JsonSerializer.Serialize(items ?? Array.Empty<T>(), JsonSerializerOptions);
 
     private static PromptSelectionResult ParsePromptSelection(string? responseText, PromptContext context)
     {
@@ -226,7 +223,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
 
         try
         {
-            response = JsonSerializer.Deserialize<PromptSelectionResponse>(jsonText, ResponseJsonSerializerOptions);
+            response = JsonSerializer.Deserialize<PromptSelectionResponse>(jsonText, JsonSerializerOptions);
             return !string.IsNullOrWhiteSpace(response?.ImagePrompt);
         }
         catch (JsonException)


### PR DESCRIPTION
## 概要
- issue #34 の不整合を修正し、候補コンテキストの採用判定をプロンプト生成段へ移しました
- `ContextService` の事前絞り込みをやめ、取得した予定 5 件・ニュース 5 件をそのまま Gemini へ渡すようにしました
- テキストモデルの応答を `imagePrompt` と `selectedNewsIds` を含む JSON として扱い、選ばれたニュースに対応する OGP 画像だけを画像生成へ添付するようにしました

## 原因
- これまでは「明日の予定があるならその予定だけ残してニュースを除外する」前処理がありました
- その後で「ポジティブな予定だけ採用する」規則が走るため、明日の予定がネガティブ/ニュートラルだと他の予定やニュースまで消えていました

## 変更点
- `PromptContext` を候補リスト中心の内部表現に変更
- `ContextService.BuildContextAsync()` で候補を削らず、全候補に proximity tag を付けて渡す形に変更
- `GoogleAiService` で候補一覧 JSON を元に採用判定と画像プロンプト生成を行うよう変更
- `check-google-ai` のサンプル入力を新しい `PromptContext` 形式に更新

## 確認
- `dotnet build WondayWall\WondayWall.csproj --no-restore`