### PR TITLE
[codex] Mutex解放時のスレッド所有権例外を修正する

### DIFF
--- a/WondayWall/Services/GenerationCoordinator.cs
+++ b/WondayWall/Services/GenerationCoordinator.cs
@@ -129,7 +129,7 @@ public class GenerationCoordinator(
 
     // GUI と CLI が別プロセスで同時起動し得るため、OS 全体で共有する Mutex で直列化する。
     private static Task<T> ExecuteWithGenerationMutexAsync<T>(Func<Task<T>> action, CancellationToken ct)
-        => Task.Run(async () =>
+        => Task.Run(() =>
             {
                 using var mutex = new Mutex(false, GenerationMutexName);
                 var hasHandle = false;
@@ -150,7 +150,8 @@ public class GenerationCoordinator(
                         }
                     }
 
-                    return await action();
+                    // Mutex はスレッド所有権を持つため、取得したスレッドで処理完了まで待ってから解放する。
+                    return action().GetAwaiter().GetResult();
                 }
                 finally
                 {


### PR DESCRIPTION
## 概要
- Issue #52 の `ReleaseMutex` が所有スレッド以外から呼ばれて例外になる問題を修正しました。
- named Mutex による GUI/CLI 間のクロスプロセス直列化は維持しています。

## 原因
- `Task.Run(async () => ...)` 内で Mutex を取得したあとに `await action()` していたため、継続が別の ThreadPool スレッドで実行される可能性がありました。
- その場合、Mutex を所有していないスレッドから `ReleaseMutex` が呼ばれて `ApplicationException` が発生します。

## 対応
- Mutex を取得する `Task.Run` ラムダを非 `async` に変更しました。
- Mutex 所有中は `action().GetAwaiter().GetResult()` で完了まで待ち、取得した同じスレッドから `ReleaseMutex` するようにしました。
- `run-once` のスロット判定と生成を同じロック内に置く構造、`AbandonedMutexException` の扱い、キャンセル待機は維持しています。

## 検証
- `dotnet build WondayWall\WondayWall.csproj --no-restore`

Closes #52