### PR TITLE
[codex] 管理ファイルの保存先をLocalApplicationDataに統一

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Program.cs
 
 | サービス | 責務 |
 |---------|------|
-| `AppConfigService` | JSON 設定の読み書き（`%AppData%/WondayWall/appsettings.json`） |
+| `AppConfigService` | JSON 設定の読み書き（`%LocalAppData%/WondayWall/config.json`） |
 | `ContextService` | Google Calendar + RSS フィードからプロンプトコンテキストを構築 |
 | `GoogleAiService` | Gemini API で壁紙画像を生成・保存 |
 | `WallpaperService` | Win32 API で壁紙を適用 |
@@ -73,7 +73,7 @@ Program.cs
 
 ### 設定・データ保存
 
-- 設定・履歴・OAuth トークン・生成画像はすべて `%AppData%/WondayWall/` 以下に保存。
+- 設定・履歴・OAuth トークン・生成画像はすべて `%LocalAppData%/WondayWall/` 以下に保存。
 - 履歴は `history.json`（JSON ファイル、DB は使わない）。
 
 ### 非同期
@@ -84,6 +84,6 @@ Program.cs
 ## よくある落とし穴
 
 - **`StartupObject` の削除禁止**: `<StartupObject>WondayWall.Program</StartupObject>` を削除すると WPF デフォルトエントリーポイントになり CLI モードが壊れる。
-- **OAuth トークンキャッシュ**: `%AppData%/WondayWall/calendar-token/` に保存。クレデンシャル変更後は手動削除が必要。
+- **OAuth トークンキャッシュ**: `%LocalAppData%/WondayWall/calendar-token/` に保存。クレデンシャル変更後は手動削除が必要。
 - **プロンプトサイズ**: カレンダーは5件、ニュースは最大10件に絞って送信。それ以上に増やす場合は GenAI API の制限を確認。
 - **`IsGenerating` フラグ**: 生成中はボタンを無効化する設計。`CanExecuteChanged` を忘れずに呼ぶ。

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ WondayWall.exe check-google-ai   # Gemini API 接続確認
 
 | 種別 | パス |
 |------|------|
-| 設定ファイル | `%AppData%\WondayWall\appsettings.json` |
-| 生成履歴 | `%AppData%\WondayWall\history.json` |
-| 生成画像 | `%AppData%\WondayWall\images\` |
-| OAuth トークン | `%AppData%\WondayWall\calendar-token\` |
+| 設定ファイル | `%LocalAppData%\WondayWall\config.json` |
+| 生成履歴 | `%LocalAppData%\WondayWall\history.json` |
+| 生成画像 | `%LocalAppData%\WondayWall\wallpapers\` |
+| OAuth トークン | `%LocalAppData%\WondayWall\calendar-token\` |
 
 ## スケジュール
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,6 +33,6 @@
 ## 対象になりやすい領域
 
 - Google API キーや OAuth トークンの取り扱い
-- `%AppData%/WondayWall/` 配下の設定や履歴の保存
+- `%LocalAppData%/WondayWall/` 配下の設定や履歴の保存
 - 生成画像やローカルファイルの扱い
 - インストーラーや更新導線

--- a/WondayWall/Services/AppConfigService.cs
+++ b/WondayWall/Services/AppConfigService.cs
@@ -7,7 +7,7 @@ namespace WondayWall.Services;
 public class AppConfigService
 {
     private static readonly string ConfigDirectory =
-        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "WondayWall");
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "WondayWall");
 
     private static readonly string ConfigFilePath =
         Path.Combine(ConfigDirectory, "config.json");

--- a/WondayWall/Services/ContextService.cs
+++ b/WondayWall/Services/ContextService.cs
@@ -475,7 +475,7 @@ public class ContextService(AppConfigService configService, HistoryService histo
     private static FileDataStore CreateCalendarTokenStore()
     {
         var credPath = Path.Combine(
-            System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData),
+            System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData),
             "WondayWall", "calendar-token");
         return new FileDataStore(credPath, true);
     }

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -14,7 +14,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
 {
     private readonly HttpClient httpClient = httpClientFactory.CreateClient("WondayWall");
     private static readonly string FixedImageSavePath = Path.Combine(
-        System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData),
+        System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData),
         "WondayWall", "wallpapers");
     private static readonly JsonSerializerOptions JsonSerializerOptions = new()
     {

--- a/WondayWall/Services/HistoryService.cs
+++ b/WondayWall/Services/HistoryService.cs
@@ -9,7 +9,7 @@ public class HistoryService
     private const int MaxHistoryItems = 100;
 
     private static readonly string HistoryFilePath =
-        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "WondayWall", "history.json");
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "WondayWall", "history.json");
 
     public List<HistoryItem> Load()
         => JsonFileHelper.Load<List<HistoryItem>>(HistoryFilePath) ?? [];


### PR DESCRIPTION
## 概要
- 管理ファイルの保存先を `%AppData%\WondayWall` から `%LocalAppData%\WondayWall` に統一
- 設定、履歴、OAuth トークン、生成画像の保存先を LocalApplicationData 配下へ変更
- 互換性は不要という issue #51 の前提に従い、旧パスからの読み取り・移行・削除処理は追加しない
- README / SECURITY / AGENTS の保存先表記を実装に合わせて更新

## 検証
- `rg "SpecialFolder.ApplicationData|%AppData%|appsettings.json|images\\" .`
- `dotnet restore WondayWall\WondayWall.csproj`
- `dotnet build WondayWall\WondayWall.csproj --no-restore`

Closes #51