### PR TITLE
Add CredentialSecret対応をJsonFileHelperに統合する

### DIFF
--- a/WondayWall/ComponentModel/CredentialSecretAttribute.cs
+++ b/WondayWall/ComponentModel/CredentialSecretAttribute.cs
@@ -1,0 +1,4 @@
+namespace WondayWall.ComponentModel;
+
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class CredentialSecretAttribute : Attribute;

--- a/WondayWall/ComponentModel/CredentialSecretJsonConverter.cs
+++ b/WondayWall/ComponentModel/CredentialSecretJsonConverter.cs
@@ -1,0 +1,59 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using WondayWall.Utils;
+
+namespace WondayWall.ComponentModel;
+
+internal sealed class CredentialSecretJsonConverter(string jsonPath) : JsonConverter<string>
+{
+    public override bool HandleNull => true;
+
+    public static void Apply(JsonTypeInfo typeInfo)
+    {
+        if (typeInfo.Kind != JsonTypeInfoKind.Object)
+            return;
+
+        foreach (var property in typeInfo.Properties)
+        {
+            if (property.AttributeProvider?.IsDefined(typeof(CredentialSecretAttribute), inherit: true) != true)
+                continue;
+
+            if (property.PropertyType != typeof(string))
+                throw new InvalidOperationException("[CredentialSecret] can only be used on string properties.");
+
+            property.CustomConverter = new CredentialSecretJsonConverter($"$.{property.Name}");
+        }
+    }
+
+    public override string Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+            return string.Empty;
+
+        var storedId = reader.GetString();
+        return storedId == jsonPath
+            ? CredentialSecretStore.Read(jsonPath)
+            : string.Empty;
+    }
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        string value,
+        JsonSerializerOptions options)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            CredentialSecretStore.Delete(jsonPath);
+            writer.WriteStringValue(string.Empty);
+            return;
+        }
+
+        CredentialSecretStore.Write(jsonPath, value);
+        writer.WriteStringValue(jsonPath);
+    }
+}

--- a/WondayWall/Models/AppConfig.cs
+++ b/WondayWall/Models/AppConfig.cs
@@ -1,7 +1,10 @@
+using WondayWall.ComponentModel;
+
 namespace WondayWall.Models;
 
 public class AppConfig
 {
+    [CredentialSecret]
     public string GoogleAiApiKey { get; set; } = string.Empty;
     public List<string> TargetCalendarIds { get; set; } = [];
     public List<string> RssSources { get; set; } = [];

--- a/WondayWall/Utils/CredentialSecretStore.cs
+++ b/WondayWall/Utils/CredentialSecretStore.cs
@@ -1,0 +1,70 @@
+using Windows.Security.Credentials;
+
+namespace WondayWall.Utils;
+
+internal static class CredentialSecretStore
+{
+    public const string ResourceName = "StudioFreesia.WondayWall.AppConfig";
+
+    private const uint ElementNotFound = 0x80070490;
+    private static readonly PasswordVault Vault = new();
+    private static readonly object SyncRoot = new();
+
+    public static string Read(string jsonPath)
+    {
+        try
+        {
+            lock (SyncRoot)
+            {
+                var credential = Vault.Retrieve(ResourceName, jsonPath);
+                credential.RetrievePassword();
+                return credential.Password ?? string.Empty;
+            }
+        }
+        catch (Exception ex) when (IsElementNotFound(ex))
+        {
+            return string.Empty;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Failed to read credential secret '{jsonPath}': {ex.Message}");
+            return string.Empty;
+        }
+    }
+
+    public static void Write(string jsonPath, string value)
+    {
+        lock (SyncRoot)
+        {
+            DeleteCore(jsonPath);
+
+            if (string.IsNullOrEmpty(value))
+                return;
+
+            Vault.Add(new PasswordCredential(ResourceName, jsonPath, value));
+        }
+    }
+
+    public static void Delete(string jsonPath)
+    {
+        lock (SyncRoot)
+        {
+            DeleteCore(jsonPath);
+        }
+    }
+
+    private static void DeleteCore(string jsonPath)
+    {
+        try
+        {
+            var credential = Vault.Retrieve(ResourceName, jsonPath);
+            Vault.Remove(credential);
+        }
+        catch (Exception ex) when (IsElementNotFound(ex))
+        {
+        }
+    }
+
+    private static bool IsElementNotFound(Exception ex)
+        => unchecked((uint)ex.HResult) == ElementNotFound;
+}

--- a/WondayWall/Utils/JsonFileHelper.cs
+++ b/WondayWall/Utils/JsonFileHelper.cs
@@ -1,16 +1,29 @@
+using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using System.IO;
+using WondayWall.ComponentModel;
 
 namespace WondayWall.Utils;
 
 public static class JsonFileHelper
 {
+    private static readonly DefaultJsonTypeInfoResolver TypeInfoResolver = CreateTypeInfoResolver();
+
     private static readonly JsonSerializerOptions Options = new()
     {
         WriteIndented = true,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        TypeInfoResolver = TypeInfoResolver,
     };
+
+    private static DefaultJsonTypeInfoResolver CreateTypeInfoResolver()
+    {
+        var resolver = new DefaultJsonTypeInfoResolver();
+        resolver.Modifiers.Add(CredentialSecretJsonConverter.Apply);
+        return resolver;
+    }
 
     public static T? Load<T>(string filePath) where T : class
     {


### PR DESCRIPTION
## Summary
- `[CredentialSecret]` 付き `string` プロパティにだけ `JsonConverter` を差し込むようにした
- `AppConfig.GoogleAiApiKey` を `PasswordVault` に保存し、JSON には `$.googleAiApiKey` のみを書き出す
- `PasswordVault` のインスタンスをキャッシュして、読み書きと削除をまとめて扱うようにした

## Testing
- `dotnet build WondayWall\WondayWall.csproj --no-restore` を実行し、ビルド成功を確認した
- `dotnet run --project WondayWall\WondayWall.csproj --no-restore --no-build -- check-news` で起動経路の初期化を確認した