### PR TITLE
[codex] Google AI呼び出しtierを実行モード別に切り替える

### DIFF
--- a/WondayWall/Commands/CliCommands.cs
+++ b/WondayWall/Commands/CliCommands.cs
@@ -78,16 +78,17 @@ public class CliCommands(
                         Summary: "Sample news summary")
                 ],
                 ImageSize: "1920x1080"),
+            GoogleAiServiceTier.Standard,
             cancellationToken);
-        logger.LogInformation("Success! Image saved to: {Path}", info.FilePath);
+        logger.LogInformation("Success! Image saved to: {Path} ({ServiceTier})", info.FilePath, info.ServiceTier);
     }
 
     private void LogRunResult(HistoryItem result)
     {
         if (result.IsSkipped)
-            logger.LogInformation("Skipped: no changes detected.");
+            logger.LogInformation("Skipped: no changes detected. ({ServiceTier})", result.ServiceTier);
         else if (result.IsSuccess)
-            logger.LogInformation("Done. Wallpaper set: {Path}", result.AppliedImagePath);
+            logger.LogInformation("Done. Wallpaper set: {Path} ({ServiceTier})", result.AppliedImagePath, result.ServiceTier);
         else
             logger.LogError("Failed: {Error}", result.ErrorSummary);
     }

--- a/WondayWall/ComponentModel/GenerativeModelEx.cs
+++ b/WondayWall/ComponentModel/GenerativeModelEx.cs
@@ -8,12 +8,6 @@ namespace WondayWall.ComponentModel;
 internal class GenerativeModelEx(string apiKey, string? model, GenerationConfig? config = null, ICollection<SafetySetting>? safetySettings = null, string? systemInstruction = null, HttpClient? httpClient = null, ILogger? logger = null)
     : GenerativeModel(apiKey, model, config, safetySettings, systemInstruction, httpClient, logger)
 {
-    public void PrepareRequestForGenerateContent(GenerateContentRequest request)
-    {
-        ValidateGenerateContentRequest(request);
-        PrepareRequest(request);
-    }
-
     protected override void ValidateGenerateContentRequest(GenerateContentRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);

--- a/WondayWall/ComponentModel/GenerativeModelEx.cs
+++ b/WondayWall/ComponentModel/GenerativeModelEx.cs
@@ -8,6 +8,12 @@ namespace WondayWall.ComponentModel;
 internal class GenerativeModelEx(string apiKey, string? model, GenerationConfig? config = null, ICollection<SafetySetting>? safetySettings = null, string? systemInstruction = null, HttpClient? httpClient = null, ILogger? logger = null)
     : GenerativeModel(apiKey, model, config, safetySettings, systemInstruction, httpClient, logger)
 {
+    public void PrepareRequestForGenerateContent(GenerateContentRequest request)
+    {
+        ValidateGenerateContentRequest(request);
+        PrepareRequest(request);
+    }
+
     protected override void ValidateGenerateContentRequest(GenerateContentRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);

--- a/WondayWall/ComponentModel/GenerativeModelEx.cs
+++ b/WondayWall/ComponentModel/GenerativeModelEx.cs
@@ -1,11 +1,21 @@
-﻿using System.Net.Http;
+using System.Net.Http;
+using System.Text.Json.Serialization;
 using GenerativeAI;
 using GenerativeAI.Types;
 using Microsoft.Extensions.Logging;
+using WondayWall.Models;
 
 namespace WondayWall.ComponentModel;
 
-internal class GenerativeModelEx(string apiKey, string? model, GenerationConfig? config = null, ICollection<SafetySetting>? safetySettings = null, string? systemInstruction = null, HttpClient? httpClient = null, ILogger? logger = null)
+internal class GenerativeModelEx(
+    string apiKey,
+    string? model,
+    GenerationConfig? config = null,
+    ICollection<SafetySetting>? safetySettings = null,
+    string? systemInstruction = null,
+    HttpClient? httpClient = null,
+    ILogger? logger = null,
+    GoogleAiServiceTier serviceTier = GoogleAiServiceTier.Standard)
     : GenerativeModel(apiKey, model, config, safetySettings, systemInstruction, httpClient, logger)
 {
     protected override void ValidateGenerateContentRequest(GenerateContentRequest request)
@@ -15,5 +25,52 @@ internal class GenerativeModelEx(string apiKey, string? model, GenerationConfig?
         if (CachedContent != null && (UseGrounding || UseGoogleSearch || UseCodeExecutionTool))
             throw new NotSupportedException(
                 "Cached content mode does not support the use of grounding, Google Search, or code execution tools. Please disable these features.");
+    }
+
+    public override async Task<GenerateContentResponse> GenerateContentAsync(
+        GenerateContentRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        PrepareRequest(request);
+        return await CallFunctionAsync(
+            request,
+            await GenerateContentAsync(Model, request).ConfigureAwait(false),
+            cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    protected override async Task<GenerateContentResponse> GenerateContentAsync(string model, GenerateContentRequest request)
+    {
+        if (serviceTier != GoogleAiServiceTier.Flex)
+            return await base.GenerateContentAsync(model, request).ConfigureAwait(false);
+
+        var url = $"{Platform.GetBaseUrl()}/{model.ToModelId()}:generateContent";
+        var response = await SendAsync<ServiceTierGenerateContentRequest, GenerateContentResponse>(
+            url,
+            new ServiceTierGenerateContentRequest(request),
+            HttpMethod.Post)
+            .ConfigureAwait(false);
+        CheckBlockedResponse(response, url);
+        return response;
+    }
+
+    private sealed class ServiceTierGenerateContentRequest(GenerateContentRequest request)
+    {
+        public List<Content>? Contents { get; init; } = request.Contents;
+
+        public List<Tool>? Tools { get; init; } = request.Tools;
+
+        public ToolConfig? ToolConfig { get; init; } = request.ToolConfig;
+
+        public List<SafetySetting>? SafetySettings { get; init; } = request.SafetySettings;
+
+        public Content? SystemInstruction { get; init; } = request.SystemInstruction;
+
+        public GenerationConfig? GenerationConfig { get; init; } = request.GenerationConfig;
+
+        public string? CachedContent { get; init; } = request.CachedContent;
+
+        [JsonPropertyName("service_tier")]
+        public string ServiceTier { get; init; } = "flex";
     }
 }

--- a/WondayWall/ComponentModel/GenerativeModelEx.cs
+++ b/WondayWall/ComponentModel/GenerativeModelEx.cs
@@ -54,21 +54,18 @@ internal class GenerativeModelEx(
         return response;
     }
 
-    private sealed class ServiceTierGenerateContentRequest(GenerateContentRequest request)
+    private sealed class ServiceTierGenerateContentRequest : GenerateContentRequest
     {
-        public List<Content>? Contents { get; init; } = request.Contents;
-
-        public List<Tool>? Tools { get; init; } = request.Tools;
-
-        public ToolConfig? ToolConfig { get; init; } = request.ToolConfig;
-
-        public List<SafetySetting>? SafetySettings { get; init; } = request.SafetySettings;
-
-        public Content? SystemInstruction { get; init; } = request.SystemInstruction;
-
-        public GenerationConfig? GenerationConfig { get; init; } = request.GenerationConfig;
-
-        public string? CachedContent { get; init; } = request.CachedContent;
+        public ServiceTierGenerateContentRequest(GenerateContentRequest request)
+        {
+            Contents = request.Contents;
+            Tools = request.Tools;
+            ToolConfig = request.ToolConfig;
+            SafetySettings = request.SafetySettings;
+            SystemInstruction = request.SystemInstruction;
+            GenerationConfig = request.GenerationConfig;
+            CachedContent = request.CachedContent;
+        }
 
         [JsonPropertyName("service_tier")]
         public string ServiceTier { get; init; } = "flex";

--- a/WondayWall/Models/GeneratedImageInfo.cs
+++ b/WondayWall/Models/GeneratedImageInfo.cs
@@ -4,4 +4,5 @@ public record GeneratedImageInfo(
     string FilePath,
     DateTime GeneratedAt,
     string UsedPrompt,
+    GoogleAiServiceTier ServiceTier,
     PromptContext? SourceContext = null);

--- a/WondayWall/Models/GoogleAiServiceTier.cs
+++ b/WondayWall/Models/GoogleAiServiceTier.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace WondayWall.Models;
+
+[JsonConverter(typeof(JsonStringEnumConverter<GoogleAiServiceTier>))]
+public enum GoogleAiServiceTier
+{
+    Standard,
+    Flex,
+}

--- a/WondayWall/Models/HistoryItem.cs
+++ b/WondayWall/Models/HistoryItem.cs
@@ -7,4 +7,5 @@ public record HistoryItem(
     string? AppliedImagePath = null,
     List<CalendarEventItem>? UsedCalendarEvents = null,
     List<NewsTopicItem>? UsedNewsTopics = null,
+    GoogleAiServiceTier? ServiceTier = null,
     bool IsSkipped = false);

--- a/WondayWall/Program.cs
+++ b/WondayWall/Program.cs
@@ -43,6 +43,7 @@ static void ConfigureCommonServices(IServiceCollection services)
 {
     services.AddLogging(b => b.AddConsole());
     services.AddHttpClient("WondayWall", c => c.Timeout = TimeSpan.FromSeconds(30));
+    services.AddHttpClient("Gemini", c => c.Timeout = TimeSpan.FromMinutes(10));
     services.AddSingleton<WallpaperService>();
     services.AddSingleton<AppConfigService>();
     services.AddSingleton<HistoryService>();

--- a/WondayWall/Program.cs
+++ b/WondayWall/Program.cs
@@ -51,8 +51,8 @@ static void ConfigureCommonServices(IServiceCollection services)
             "Gemini",
             c =>
             {
-                c.Timeout = TimeSpan.FromMinutes(10);
-                c.DefaultRequestHeaders.TryAddWithoutValidation("X-Server-Timeout", "600");
+                c.Timeout = TimeSpan.FromMinutes(30);
+                c.DefaultRequestHeaders.TryAddWithoutValidation("X-Server-Timeout", "1800");
             })
         .AddResilienceHandler("GoogleAiRetry", static builder => builder.AddRetry(new HttpRetryStrategyOptions()));
     services.AddSingleton<WallpaperService>();

--- a/WondayWall/Program.cs
+++ b/WondayWall/Program.cs
@@ -3,6 +3,8 @@ using Kamishibai;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Polly;
+using Polly.Retry;
 using Windows.Win32;
 using WondayWall;
 using WondayWall.Commands;
@@ -46,6 +48,34 @@ static void ConfigureCommonServices(IServiceCollection services)
     services.AddLogging(b => b.AddConsole());
     services.AddHttpClient("WondayWall", c => c.Timeout = TimeSpan.FromSeconds(30));
     services.AddHttpClient("Gemini", c => c.Timeout = TimeSpan.FromMinutes(10));
+    services.AddResiliencePipeline(GoogleAiService.FlexRetryPipelineName, static (builder, context) =>
+    {
+        var logger = context.ServiceProvider.GetRequiredService<ILogger<GoogleAiService>>();
+        builder.AddRetry(new RetryStrategyOptions
+        {
+            MaxRetryAttempts = GoogleAiService.MaxFlexAttempts - 1,
+            DelayGenerator = static args => new ValueTask<TimeSpan?>(
+                GoogleAiService.GetFlexRetryDelay(args.AttemptNumber + 1)),
+            ShouldHandle = static args =>
+            {
+                var exception = args.Outcome.Exception;
+                return new ValueTask<bool>(
+                    exception != null
+                    && GoogleAiService.IsRetryableFlexFailure(exception, args.Context.CancellationToken));
+            },
+            OnRetry = args =>
+            {
+                var failedAttempt = args.AttemptNumber + 1;
+                logger.LogWarning(
+                    args.Outcome.Exception,
+                    "Google AI Flex 呼び出しに失敗しました ({Attempt}/{MaxAttempts})。{DelaySeconds} 秒後に再試行します。",
+                    failedAttempt,
+                    GoogleAiService.MaxFlexAttempts,
+                    args.RetryDelay.TotalSeconds);
+                return default;
+            },
+        });
+    });
     services.AddSingleton<WallpaperService>();
     services.AddSingleton<AppConfigService>();
     services.AddSingleton<HistoryService>();

--- a/WondayWall/Program.cs
+++ b/WondayWall/Program.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Polly;
-using Polly.Retry;
 using Windows.Win32;
 using WondayWall;
 using WondayWall.Commands;
@@ -48,33 +47,9 @@ static void ConfigureCommonServices(IServiceCollection services)
     services.AddLogging(b => b.AddConsole());
     services.AddHttpClient("WondayWall", c => c.Timeout = TimeSpan.FromSeconds(30));
     services.AddHttpClient("Gemini", c => c.Timeout = TimeSpan.FromMinutes(10));
-    services.AddResiliencePipeline(GoogleAiService.FlexRetryPipelineName, static (builder, context) =>
+    services.AddResiliencePipeline(GoogleAiService.GoogleAiRetryPipelineName, static builder =>
     {
-        var logger = context.ServiceProvider.GetRequiredService<ILogger<GoogleAiService>>();
-        builder.AddRetry(new RetryStrategyOptions
-        {
-            MaxRetryAttempts = GoogleAiService.MaxFlexAttempts - 1,
-            DelayGenerator = static args => new ValueTask<TimeSpan?>(
-                GoogleAiService.GetFlexRetryDelay(args.AttemptNumber + 1)),
-            ShouldHandle = static args =>
-            {
-                var exception = args.Outcome.Exception;
-                return new ValueTask<bool>(
-                    exception != null
-                    && GoogleAiService.IsRetryableFlexFailure(exception, args.Context.CancellationToken));
-            },
-            OnRetry = args =>
-            {
-                var failedAttempt = args.AttemptNumber + 1;
-                logger.LogWarning(
-                    args.Outcome.Exception,
-                    "Google AI Flex 呼び出しに失敗しました ({Attempt}/{MaxAttempts})。{DelaySeconds} 秒後に再試行します。",
-                    failedAttempt,
-                    GoogleAiService.MaxFlexAttempts,
-                    args.RetryDelay.TotalSeconds);
-                return default;
-            },
-        });
+        builder.AddRetry(new());
     });
     services.AddSingleton<WallpaperService>();
     services.AddSingleton<AppConfigService>();

--- a/WondayWall/Program.cs
+++ b/WondayWall/Program.cs
@@ -1,6 +1,7 @@
 using ConsoleAppFramework;
 using Kamishibai;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Polly;
@@ -46,11 +47,14 @@ static void ConfigureCommonServices(IServiceCollection services)
 {
     services.AddLogging(b => b.AddConsole());
     services.AddHttpClient("WondayWall", c => c.Timeout = TimeSpan.FromSeconds(30));
-    services.AddHttpClient("Gemini", c => c.Timeout = TimeSpan.FromMinutes(10));
-    services.AddResiliencePipeline(GoogleAiService.GoogleAiRetryPipelineName, static builder =>
-    {
-        builder.AddRetry(new());
-    });
+    services.AddHttpClient(
+            "Gemini",
+            c =>
+            {
+                c.Timeout = TimeSpan.FromMinutes(10);
+                c.DefaultRequestHeaders.TryAddWithoutValidation("X-Server-Timeout", "600");
+            })
+        .AddResilienceHandler("GoogleAiRetry", static builder => builder.AddRetry(new HttpRetryStrategyOptions()));
     services.AddSingleton<WallpaperService>();
     services.AddSingleton<AppConfigService>();
     services.AddSingleton<HistoryService>();

--- a/WondayWall/Services/GenerationCoordinator.cs
+++ b/WondayWall/Services/GenerationCoordinator.cs
@@ -17,7 +17,7 @@ public class GenerationCoordinator(
     private static readonly TimeSpan GenerationMutexWaitInterval = TimeSpan.FromMilliseconds(250);
 
     public Task<HistoryItem> RunAsync(bool skipIfNoChanges = false, CancellationToken ct = default)
-        => ExecuteWithGenerationMutexAsync(() => RunCoreAsync(skipIfNoChanges, ct), ct);
+        => ExecuteWithGenerationMutexAsync(() => RunCoreAsync(GoogleAiServiceTier.Standard, skipIfNoChanges, ct), ct);
 
     public Task<HistoryItem?> RunScheduledAsync(
         bool skipIfNoChanges = false,
@@ -38,11 +38,11 @@ public class GenerationCoordinator(
                 runsPerDay,
                 scheduledSlot.Value);
 
-            return await RunCoreAsync(skipIfNoChanges, ct);
+            return await RunCoreAsync(GoogleAiServiceTier.Flex, skipIfNoChanges, ct);
         }, ct);
     }
 
-    private async Task<HistoryItem> RunCoreAsync(bool skipIfNoChanges, CancellationToken ct)
+    private async Task<HistoryItem> RunCoreAsync(GoogleAiServiceTier serviceTier, bool skipIfNoChanges, CancellationToken ct)
     {
         bool isSuccess = false;
         bool isSkipped = false;
@@ -50,6 +50,7 @@ public class GenerationCoordinator(
         string? appliedImagePath = null;
         List<CalendarEventItem>? usedEvents = null;
         List<NewsTopicItem>? usedTopics = null;
+        var usedServiceTier = serviceTier;
         var historyItems = historyService.Load();
 
         try
@@ -82,7 +83,8 @@ public class GenerationCoordinator(
             }
             else
             {
-                var imageInfo = await googleAiService.GenerateWallpaperAsync(promptContext, ct);
+                var imageInfo = await googleAiService.GenerateWallpaperAsync(promptContext, serviceTier, ct);
+                usedServiceTier = imageInfo.ServiceTier;
                 await wallpaperService.SetWallpaperAsync(
                     imageInfo.FilePath,
                     configService.Current.UpdateLockScreen,
@@ -106,6 +108,7 @@ public class GenerationCoordinator(
             AppliedImagePath: appliedImagePath,
             UsedCalendarEvents: usedEvents,
             UsedNewsTopics: usedTopics,
+            ServiceTier: usedServiceTier,
             IsSkipped: isSkipped);
 
         try

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -102,13 +102,13 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         // ステップ1: テキストモデルで詳細な画像プロンプトを生成（Google検索グラウンディングを有効化）
         var textModel = new GenerativeModelEx(apiKey, TextModelName, httpClient: geminiHttpClient)
         {
-            UseGoogleSearch = true,
             UseJsonMode = true,
         };
         var contextPrompt = BuildTextModelPrompt(context);
         var promptRequest = new GenerateContentRequest();
         promptRequest.UseJsonMode<PromptSelectionResponse>(JsonSerializerOptions);
         promptRequest.AddText(contextPrompt);
+        AddGoogleSearchTool(promptRequest);
 
         var promptResponse = await GenerateContentAsync(textModel, promptRequest, serviceTier, apiKey, ct);
         var promptSelection = promptResponse.ToObject<PromptSelectionResponse>(JsonSerializerOptions);
@@ -189,10 +189,9 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
                 ImageSize = displayInfo.ImageSize,
             }
         };
-        var imageModel = new GenerativeModelEx(apiKey, ImageModelName, genConfig, httpClient: geminiHttpClient)
-        {
-            UseGoogleSearch = true,
-        };
+        imageRequest.GenerationConfig = genConfig;
+        AddGoogleSearchTool(imageRequest);
+        var imageModel = new GenerativeModelEx(apiKey, ImageModelName, httpClient: geminiHttpClient);
 
         var response = await GenerateContentAsync(imageModel, imageRequest, serviceTier, apiKey, ct);
 
@@ -289,8 +288,6 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         if (serviceTier == GoogleAiServiceTier.Standard)
             return await model.GenerateContentAsync(request, cancellationToken: ct);
 
-        model.PrepareRequestForGenerateContent(request);
-
         var requestNode = JsonSerializer.SerializeToNode(
             request,
             TypesSerializerContext.Default.GenerateContentRequest);
@@ -368,6 +365,18 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
             json,
             TypesSerializerContext.Default.GenerateContentRequest)
             ?? throw new InvalidOperationException("Failed to clone Google AI request.");
+    }
+
+    private static void AddGoogleSearchTool(GenerateContentRequest request)
+    {
+        request.Tools ??= [];
+        if (request.Tools.Any(static tool => tool.GoogleSearch != null))
+            return;
+
+        request.Tools.Add(new Tool
+        {
+            GoogleSearch = new GoogleSearchTool(),
+        });
     }
 
     private static bool IsRetryableFlexFailure(Exception ex, CancellationToken ct)

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -1,16 +1,10 @@
-using System.Globalization;
 using System.IO;
-using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using GenerativeAI;
 using GenerativeAI.Exceptions;
 using GenerativeAI.Types;
 using Microsoft.Extensions.Logging;
-using Polly;
-using Polly.Registry;
 using WondayWall.ComponentModel;
 using WondayWall.Models;
 using WondayWall.Utils;
@@ -20,21 +14,17 @@ namespace WondayWall.Services;
 public class GoogleAiService(
     AppConfigService configService,
     IHttpClientFactory httpClientFactory,
-    ILogger<GoogleAiService> logger,
-    ResiliencePipelineProvider<string> resiliencePipelineProvider)
+    ILogger<GoogleAiService> logger)
 {
-    internal const string GoogleAiRetryPipelineName = "GoogleAiRetry";
     private const string GoogleAiApiKeyPageUrl = "https://aistudio.google.com/app/api-keys";
     private const string PaidTierRequiredMessage =
         "無料枠または課金未設定の Google AI API キーでは、この画像生成機能を利用できません。Google AI Studio で課金設定済みのプロジェクト/APIキーを確認してください: "
         + GoogleAiApiKeyPageUrl;
     private const string TextModelName = "gemini-3-flash-preview";
     private const string ImageModelName = "gemini-3.1-flash-image-preview";
-    private const int FlexServerTimeoutSeconds = 600;
 
     private readonly HttpClient ogpHttpClient = httpClientFactory.CreateClient("WondayWall");
     private readonly HttpClient geminiHttpClient = httpClientFactory.CreateClient("Gemini");
-    private readonly ResiliencePipeline googleAiRetryPipeline = resiliencePipelineProvider.GetPipeline(GoogleAiRetryPipelineName);
     private static readonly string FixedImageSavePath = Path.Combine(
         System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData),
         "WondayWall", "wallpapers");
@@ -103,14 +93,22 @@ public class GoogleAiService(
         CancellationToken ct)
     {
         // ステップ1: テキストモデルで詳細な画像プロンプトを生成（Google検索グラウンディングを有効化）
-        var textModel = new GenerativeModelEx(apiKey, TextModelName, httpClient: geminiHttpClient);
+        var textModel = new GenerativeModelEx(apiKey, TextModelName, httpClient: geminiHttpClient, serviceTier: serviceTier);
         var contextPrompt = BuildTextModelPrompt(context);
         var promptRequest = new GenerateContentRequest();
         promptRequest.UseJsonMode<PromptSelectionResponse>(JsonSerializerOptions);
         promptRequest.AddText(contextPrompt);
         AddGoogleSearchTool(promptRequest);
 
-        var promptResponse = await GenerateContentAsync(textModel, promptRequest, serviceTier, apiKey, ct);
+        GenerateContentResponse promptResponse;
+        try
+        {
+            promptResponse = await textModel.GenerateContentAsync(promptRequest, ct);
+        }
+        catch (ApiException ex) when (IsPaidTierRequiredError(ex))
+        {
+            throw new InvalidOperationException(PaidTierRequiredMessage, ex);
+        }
         var promptSelection = promptResponse.ToObject<PromptSelectionResponse>(JsonSerializerOptions);
 
         if (promptSelection == null || string.IsNullOrWhiteSpace(promptSelection.ImagePrompt))
@@ -177,9 +175,17 @@ public class GoogleAiService(
         CancellationToken ct)
     {
         // ステップ2: 画像モデルでアスペクト比・サイズを指定して壁紙を生成
-        var imageModel = new GenerativeModelEx(apiKey, ImageModelName, httpClient: geminiHttpClient);
+        var imageModel = new GenerativeModelEx(apiKey, ImageModelName, httpClient: geminiHttpClient, serviceTier: serviceTier);
 
-        var response = await GenerateContentAsync(imageModel, imageRequest, serviceTier, apiKey, ct);
+        GenerateContentResponse response;
+        try
+        {
+            response = await imageModel.GenerateContentAsync(imageRequest, ct);
+        }
+        catch (ApiException ex) when (IsPaidTierRequiredError(ex))
+        {
+            throw new InvalidOperationException(PaidTierRequiredMessage, ex);
+        }
 
         var imageBytes = ExtractImageBytes(response);
 
@@ -276,71 +282,6 @@ public class GoogleAiService(
         return imageRequest;
     }
 
-    private async Task<GenerateContentResponse> GenerateContentAsync(
-        GenerativeModelEx model,
-        GenerateContentRequest request,
-        GoogleAiServiceTier serviceTier,
-        string apiKey,
-        CancellationToken ct)
-        => await googleAiRetryPipeline.ExecuteAsync(
-            token => GenerateContentCoreAsync(model, request, serviceTier, apiKey, token),
-            ct);
-
-    private async ValueTask<GenerateContentResponse> GenerateContentCoreAsync(
-        GenerativeModelEx model,
-        GenerateContentRequest request,
-        GoogleAiServiceTier serviceTier,
-        string apiKey,
-        CancellationToken ct)
-    {
-        if (serviceTier == GoogleAiServiceTier.Standard)
-        {
-            try
-            {
-                return await model.GenerateContentAsync(request, cancellationToken: ct);
-            }
-            catch (ApiException ex) when (IsPaidTierRequiredError(ex))
-            {
-                throw new InvalidOperationException(PaidTierRequiredMessage, ex);
-            }
-        }
-
-        var requestNode = JsonSerializer.SerializeToNode(
-            request,
-            TypesSerializerContext.Default.GenerateContentRequest);
-        if (requestNode is not JsonObject requestObject)
-            throw new InvalidOperationException("Failed to build Google AI request JSON.");
-
-        requestObject["service_tier"] = "flex";
-
-        using var httpRequest = new HttpRequestMessage(
-            HttpMethod.Post,
-            BuildGenerateContentUrl(model.Model, apiKey));
-        httpRequest.Headers.TryAddWithoutValidation(
-            "X-Server-Timeout",
-            FlexServerTimeoutSeconds.ToString(CultureInfo.InvariantCulture));
-        httpRequest.Content = new StringContent(
-            requestObject.ToJsonString(JsonSerializerOptions),
-            Encoding.UTF8,
-            "application/json");
-
-        using var response = await geminiHttpClient.SendAsync(
-            httpRequest,
-            HttpCompletionOption.ResponseHeadersRead,
-            ct);
-        var responseJson = await response.Content.ReadAsStringAsync(ct);
-        if (!response.IsSuccessStatusCode)
-            throw new HttpRequestException(
-                BuildGoogleAiErrorMessage(response.StatusCode, response.ReasonPhrase, responseJson),
-                inner: null,
-                response.StatusCode);
-
-        return JsonSerializer.Deserialize(
-            responseJson,
-            TypesSerializerContext.Default.GenerateContentResponse)
-            ?? throw new InvalidOperationException("Google AI returned an empty response.");
-    }
-
     private static GenerateContentRequest CloneGenerateContentRequest(GenerateContentRequest request)
     {
         var json = JsonSerializer.Serialize(
@@ -362,28 +303,6 @@ public class GoogleAiService(
         {
             GoogleSearch = new GoogleSearchTool(),
         });
-    }
-
-    private static string BuildGenerateContentUrl(string? model, string apiKey)
-    {
-        if (string.IsNullOrWhiteSpace(model))
-            throw new InvalidOperationException("Google AI model is not configured.");
-
-        var normalizedModel = model.StartsWith("models/", StringComparison.Ordinal)
-            ? model
-            : $"models/{model}";
-        return $"https://generativelanguage.googleapis.com/v1beta/{normalizedModel}:generateContent?key={Uri.EscapeDataString(apiKey)}";
-    }
-
-    private static string BuildGoogleAiErrorMessage(HttpStatusCode statusCode, string? reasonPhrase, string responseBody)
-    {
-        var trimmedBody = string.IsNullOrWhiteSpace(responseBody)
-            ? "No response body."
-            : responseBody.Trim();
-        if (trimmedBody.Length > 500)
-            trimmedBody = $"{trimmedBody[..500]}...";
-
-        return $"Google AI request failed ({(int)statusCode} {reasonPhrase}): {trimmedBody}";
     }
 
     /// <summary>

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -22,15 +22,14 @@ public class GoogleAiService(
     ILogger<GoogleAiService> logger,
     ResiliencePipelineProvider<string> resiliencePipelineProvider)
 {
-    internal const string FlexRetryPipelineName = "GoogleAiFlexRetry";
-    internal const int MaxFlexAttempts = 3;
+    internal const string GoogleAiRetryPipelineName = "GoogleAiRetry";
     private const string TextModelName = "gemini-3-flash-preview";
     private const string ImageModelName = "gemini-3.1-flash-image-preview";
     private const int FlexServerTimeoutSeconds = 600;
 
     private readonly HttpClient ogpHttpClient = httpClientFactory.CreateClient("WondayWall");
     private readonly HttpClient geminiHttpClient = httpClientFactory.CreateClient("Gemini");
-    private readonly ResiliencePipeline flexRetryPipeline = resiliencePipelineProvider.GetPipeline(FlexRetryPipelineName);
+    private readonly ResiliencePipeline googleAiRetryPipeline = resiliencePipelineProvider.GetPipeline(GoogleAiRetryPipelineName);
     private static readonly string FixedImageSavePath = Path.Combine(
         System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData),
         "WondayWall", "wallpapers");
@@ -83,11 +82,9 @@ public class GoogleAiService(
 
         try
         {
-            return await ExecuteFlexWithRetriesAsync(
-                token => GeneratePromptSelectionAsync(context, GoogleAiServiceTier.Flex, apiKey, token),
-                ct);
+            return await GeneratePromptSelectionAsync(context, GoogleAiServiceTier.Flex, apiKey, ct);
         }
-        catch (Exception ex) when (IsRetryableFlexFailure(ex, ct))
+        catch (Exception ex) when (!ct.IsCancellationRequested)
         {
             logger.LogWarning(ex, "画像プロンプト生成の Flex 呼び出しが規定回数失敗したため Standard モードで再試行します。");
             return await GeneratePromptSelectionAsync(context, GoogleAiServiceTier.Standard, apiKey, ct);
@@ -144,17 +141,15 @@ public class GoogleAiService(
 
         try
         {
-            return await ExecuteFlexWithRetriesAsync(
-                token => GenerateImageAsync(
-                    context,
-                    imagePrompt,
-                    CloneGenerateContentRequest(imageRequest),
-                    GoogleAiServiceTier.Flex,
-                    apiKey,
-                    token),
+            return await GenerateImageAsync(
+                context,
+                imagePrompt,
+                CloneGenerateContentRequest(imageRequest),
+                GoogleAiServiceTier.Flex,
+                apiKey,
                 ct);
         }
-        catch (Exception ex) when (IsRetryableFlexFailure(ex, ct))
+        catch (Exception ex) when (!ct.IsCancellationRequested)
         {
             logger.LogWarning(ex, "画像生成の Flex 呼び出しが規定回数失敗したため、生成済みプロンプトを使って Standard モードで再試行します。");
             return await GenerateImageAsync(
@@ -281,6 +276,16 @@ public class GoogleAiService(
         GoogleAiServiceTier serviceTier,
         string apiKey,
         CancellationToken ct)
+        => await googleAiRetryPipeline.ExecuteAsync(
+            token => GenerateContentCoreAsync(model, request, serviceTier, apiKey, token),
+            ct);
+
+    private async ValueTask<GenerateContentResponse> GenerateContentCoreAsync(
+        GenerativeModelEx model,
+        GenerateContentRequest request,
+        GoogleAiServiceTier serviceTier,
+        string apiKey,
+        CancellationToken ct)
     {
         if (serviceTier == GoogleAiServiceTier.Standard)
             return await model.GenerateContentAsync(request, cancellationToken: ct);
@@ -321,9 +326,6 @@ public class GoogleAiService(
             ?? throw new InvalidOperationException("Google AI returned an empty response.");
     }
 
-    private async Task<T> ExecuteFlexWithRetriesAsync<T>(Func<CancellationToken, Task<T>> action, CancellationToken ct)
-        => await flexRetryPipeline.ExecuteAsync(async token => await action(token), ct);
-
     private static GenerateContentRequest CloneGenerateContentRequest(GenerateContentRequest request)
     {
         var json = JsonSerializer.Serialize(
@@ -346,32 +348,6 @@ public class GoogleAiService(
             GoogleSearch = new GoogleSearchTool(),
         });
     }
-
-    internal static bool IsRetryableFlexFailure(Exception ex, CancellationToken ct)
-    {
-        if (ct.IsCancellationRequested)
-            return false;
-
-        if (ex is TaskCanceledException or TimeoutException)
-            return true;
-
-        return ex is HttpRequestException httpException
-               && IsRetryableStatusCode(httpException.StatusCode);
-    }
-
-    private static bool IsRetryableStatusCode(HttpStatusCode? statusCode)
-        => statusCode is HttpStatusCode.TooManyRequests
-                         or HttpStatusCode.InternalServerError
-                         or HttpStatusCode.ServiceUnavailable
-                         or HttpStatusCode.GatewayTimeout;
-
-    internal static TimeSpan GetFlexRetryDelay(int attempt)
-        => attempt switch
-        {
-            1 => TimeSpan.FromSeconds(2),
-            2 => TimeSpan.FromSeconds(5),
-            _ => TimeSpan.FromSeconds(10),
-        };
 
     private static string BuildGenerateContentUrl(string? model, string apiKey)
     {

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -9,22 +9,28 @@ using GenerativeAI;
 using GenerativeAI.Types;
 using Microsoft.Extensions.Logging;
 using Polly;
-using Polly.Retry;
+using Polly.Registry;
 using WondayWall.ComponentModel;
 using WondayWall.Models;
 using WondayWall.Utils;
 
 namespace WondayWall.Services;
 
-public class GoogleAiService(AppConfigService configService, IHttpClientFactory httpClientFactory, ILogger<GoogleAiService> logger)
+public class GoogleAiService(
+    AppConfigService configService,
+    IHttpClientFactory httpClientFactory,
+    ILogger<GoogleAiService> logger,
+    ResiliencePipelineProvider<string> resiliencePipelineProvider)
 {
+    internal const string FlexRetryPipelineName = "GoogleAiFlexRetry";
+    internal const int MaxFlexAttempts = 3;
     private const string TextModelName = "gemini-3-flash-preview";
     private const string ImageModelName = "gemini-3.1-flash-image-preview";
     private const int FlexServerTimeoutSeconds = 600;
-    private const int MaxFlexAttempts = 3;
 
     private readonly HttpClient ogpHttpClient = httpClientFactory.CreateClient("WondayWall");
     private readonly HttpClient geminiHttpClient = httpClientFactory.CreateClient("Gemini");
+    private readonly ResiliencePipeline flexRetryPipeline = resiliencePipelineProvider.GetPipeline(FlexRetryPipelineName);
     private static readonly string FixedImageSavePath = Path.Combine(
         System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData),
         "WondayWall", "wallpapers");
@@ -78,8 +84,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         try
         {
             return await ExecuteFlexWithRetriesAsync(
-                () => GeneratePromptSelectionAsync(context, GoogleAiServiceTier.Flex, apiKey, ct),
-                "画像プロンプト生成",
+                token => GeneratePromptSelectionAsync(context, GoogleAiServiceTier.Flex, apiKey, token),
                 ct);
         }
         catch (Exception ex) when (IsRetryableFlexFailure(ex, ct))
@@ -140,14 +145,13 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         try
         {
             return await ExecuteFlexWithRetriesAsync(
-                () => GenerateImageAsync(
+                token => GenerateImageAsync(
                     context,
                     imagePrompt,
                     CloneGenerateContentRequest(imageRequest),
                     GoogleAiServiceTier.Flex,
                     apiKey,
-                    ct),
-                "画像生成",
+                    token),
                 ct);
         }
         catch (Exception ex) when (IsRetryableFlexFailure(ex, ct))
@@ -317,37 +321,8 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
             ?? throw new InvalidOperationException("Google AI returned an empty response.");
     }
 
-    private async Task<T> ExecuteFlexWithRetriesAsync<T>(
-        Func<Task<T>> action,
-        string operationName,
-        CancellationToken ct)
-    {
-        var retryPipeline = new ResiliencePipelineBuilder<T>()
-            .AddRetry(new RetryStrategyOptions<T>
-            {
-                MaxRetryAttempts = MaxFlexAttempts - 1,
-                DelayGenerator = args => new ValueTask<TimeSpan?>(GetFlexRetryDelay(args.AttemptNumber + 1)),
-                ShouldHandle = new PredicateBuilder<T>()
-                    .Handle<HttpRequestException>(ex => IsRetryableStatusCode(ex.StatusCode))
-                    .Handle<TaskCanceledException>(_ => !ct.IsCancellationRequested)
-                    .Handle<TimeoutException>(_ => !ct.IsCancellationRequested),
-                OnRetry = args =>
-                {
-                    var failedAttempt = args.AttemptNumber + 1;
-                    logger.LogWarning(
-                        args.Outcome.Exception,
-                        "{OperationName} の Flex 呼び出しに失敗しました ({Attempt}/{MaxAttempts})。{DelaySeconds} 秒後に再試行します。",
-                        operationName,
-                        failedAttempt,
-                        MaxFlexAttempts,
-                        args.RetryDelay.TotalSeconds);
-                    return default;
-                },
-            })
-            .Build();
-
-        return await retryPipeline.ExecuteAsync(async token => await action(), ct);
-    }
+    private async Task<T> ExecuteFlexWithRetriesAsync<T>(Func<CancellationToken, Task<T>> action, CancellationToken ct)
+        => await flexRetryPipeline.ExecuteAsync(async token => await action(token), ct);
 
     private static GenerateContentRequest CloneGenerateContentRequest(GenerateContentRequest request)
     {
@@ -372,7 +347,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         });
     }
 
-    private static bool IsRetryableFlexFailure(Exception ex, CancellationToken ct)
+    internal static bool IsRetryableFlexFailure(Exception ex, CancellationToken ct)
     {
         if (ct.IsCancellationRequested)
             return false;
@@ -390,7 +365,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
                          or HttpStatusCode.ServiceUnavailable
                          or HttpStatusCode.GatewayTimeout;
 
-    private static TimeSpan GetFlexRetryDelay(int attempt)
+    internal static TimeSpan GetFlexRetryDelay(int attempt)
         => attempt switch
         {
             1 => TimeSpan.FromSeconds(2),

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -56,16 +56,12 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
             promptResult.PromptSelection,
             promptResult.ImagePrompt,
             ct);
-        var imageServiceTier = serviceTier == GoogleAiServiceTier.Flex
-                               && promptResult.ServiceTier == GoogleAiServiceTier.Flex
-            ? GoogleAiServiceTier.Flex
-            : GoogleAiServiceTier.Standard;
 
         return await GenerateImageWithFallbackAsync(
             context,
             promptResult.ImagePrompt,
             imageRequest,
-            imageServiceTier,
+            promptResult.ServiceTier,
             config.GoogleAiApiKey,
             ct);
     }
@@ -100,10 +96,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         CancellationToken ct)
     {
         // ステップ1: テキストモデルで詳細な画像プロンプトを生成（Google検索グラウンディングを有効化）
-        var textModel = new GenerativeModelEx(apiKey, TextModelName, httpClient: geminiHttpClient)
-        {
-            UseJsonMode = true,
-        };
+        var textModel = new GenerativeModelEx(apiKey, TextModelName, httpClient: geminiHttpClient);
         var contextPrompt = BuildTextModelPrompt(context);
         var promptRequest = new GenerateContentRequest();
         promptRequest.UseJsonMode<PromptSelectionResponse>(JsonSerializerOptions);
@@ -179,18 +172,6 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         CancellationToken ct)
     {
         // ステップ2: 画像モデルでアスペクト比・サイズを指定して壁紙を生成
-        var displayInfo = DisplayHelper.GetDisplayInfo();
-        var genConfig = new GenerationConfig
-        {
-            ResponseModalities = [Modality.IMAGE],
-            ImageConfig = new ImageConfig
-            {
-                AspectRatio = displayInfo.AspectRatio,
-                ImageSize = displayInfo.ImageSize,
-            }
-        };
-        imageRequest.GenerationConfig = genConfig;
-        AddGoogleSearchTool(imageRequest);
         var imageModel = new GenerativeModelEx(apiKey, ImageModelName, httpClient: geminiHttpClient);
 
         var response = await GenerateContentAsync(imageModel, imageRequest, serviceTier, apiKey, ct);
@@ -274,6 +255,18 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
                 logger.LogWarning(ex, "OGP画像のダウンロードに失敗しました [{ImgUrl}]", imgUrl);
             }
         }
+
+        var displayInfo = DisplayHelper.GetDisplayInfo();
+        imageRequest.GenerationConfig = new GenerationConfig
+        {
+            ResponseModalities = [Modality.IMAGE],
+            ImageConfig = new ImageConfig
+            {
+                AspectRatio = displayInfo.AspectRatio,
+                ImageSize = displayInfo.ImageSize,
+            }
+        };
+        AddGoogleSearchTool(imageRequest);
 
         return imageRequest;
     }

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -8,6 +8,8 @@ using System.Text.Json.Nodes;
 using GenerativeAI;
 using GenerativeAI.Types;
 using Microsoft.Extensions.Logging;
+using Polly;
+using Polly.Retry;
 using WondayWall.ComponentModel;
 using WondayWall.Models;
 using WondayWall.Utils;
@@ -330,25 +332,31 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         string operationName,
         CancellationToken ct)
     {
-        for (var attempt = 1; ; attempt++)
-        {
-            try
+        var retryPipeline = new ResiliencePipelineBuilder<T>()
+            .AddRetry(new RetryStrategyOptions<T>
             {
-                return await action();
-            }
-            catch (Exception ex) when (attempt < MaxFlexAttempts && IsRetryableFlexFailure(ex, ct))
-            {
-                var delay = GetFlexRetryDelay(attempt);
-                logger.LogWarning(
-                    ex,
-                    "{OperationName} の Flex 呼び出しに失敗しました ({Attempt}/{MaxAttempts})。{DelaySeconds} 秒後に再試行します。",
-                    operationName,
-                    attempt,
-                    MaxFlexAttempts,
-                    delay.TotalSeconds);
-                await Task.Delay(delay, ct);
-            }
-        }
+                MaxRetryAttempts = MaxFlexAttempts - 1,
+                DelayGenerator = args => new ValueTask<TimeSpan?>(GetFlexRetryDelay(args.AttemptNumber + 1)),
+                ShouldHandle = new PredicateBuilder<T>()
+                    .Handle<HttpRequestException>(ex => IsRetryableStatusCode(ex.StatusCode))
+                    .Handle<TaskCanceledException>(_ => !ct.IsCancellationRequested)
+                    .Handle<TimeoutException>(_ => !ct.IsCancellationRequested),
+                OnRetry = args =>
+                {
+                    var failedAttempt = args.AttemptNumber + 1;
+                    logger.LogWarning(
+                        args.Outcome.Exception,
+                        "{OperationName} の Flex 呼び出しに失敗しました ({Attempt}/{MaxAttempts})。{DelaySeconds} 秒後に再試行します。",
+                        operationName,
+                        failedAttempt,
+                        MaxFlexAttempts,
+                        args.RetryDelay.TotalSeconds);
+                    return default;
+                },
+            })
+            .Build();
+
+        return await retryPipeline.ExecuteAsync(async token => await action(), ct);
     }
 
     private static GenerateContentRequest CloneGenerateContentRequest(GenerateContentRequest request)
@@ -370,14 +378,15 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         if (ex is TaskCanceledException or TimeoutException)
             return true;
 
-        return ex is HttpRequestException
-        {
-            StatusCode: HttpStatusCode.TooManyRequests
-                        or HttpStatusCode.InternalServerError
-                        or HttpStatusCode.ServiceUnavailable
-                        or HttpStatusCode.GatewayTimeout
-        };
+        return ex is HttpRequestException httpException
+               && IsRetryableStatusCode(httpException.StatusCode);
     }
+
+    private static bool IsRetryableStatusCode(HttpStatusCode? statusCode)
+        => statusCode is HttpStatusCode.TooManyRequests
+                         or HttpStatusCode.InternalServerError
+                         or HttpStatusCode.ServiceUnavailable
+                         or HttpStatusCode.GatewayTimeout;
 
     private static TimeSpan GetFlexRetryDelay(int attempt)
         => attempt switch

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -19,6 +19,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
     private const string TextModelName = "gemini-3-flash-preview";
     private const string ImageModelName = "gemini-3.1-flash-image-preview";
     private const int FlexServerTimeoutSeconds = 600;
+    private const int MaxFlexAttempts = 3;
 
     private readonly HttpClient ogpHttpClient = httpClientFactory.CreateClient("WondayWall");
     private readonly HttpClient geminiHttpClient = httpClientFactory.CreateClient("Gemini");
@@ -38,32 +39,66 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         GoogleAiServiceTier serviceTier,
         CancellationToken ct = default)
     {
-        if (serviceTier != GoogleAiServiceTier.Flex)
-            return await GenerateWallpaperCoreAsync(context, GoogleAiServiceTier.Standard, ct);
-
-        try
-        {
-            return await GenerateWallpaperCoreAsync(context, GoogleAiServiceTier.Flex, ct);
-        }
-        catch (Exception ex) when (!ct.IsCancellationRequested)
-        {
-            logger.LogWarning(ex, "Flex モードの Google AI 生成に失敗したため Standard モードで再試行します。");
-            return await GenerateWallpaperCoreAsync(context, GoogleAiServiceTier.Standard, ct);
-        }
-    }
-
-    private async Task<GeneratedImageInfo> GenerateWallpaperCoreAsync(
-        PromptContext context,
-        GoogleAiServiceTier serviceTier,
-        CancellationToken ct)
-    {
         var config = configService.Current;
 
         if (string.IsNullOrWhiteSpace(config.GoogleAiApiKey))
             throw new InvalidOperationException("Google AI API key is not configured.");
 
+        var promptResult = await GeneratePromptSelectionWithFallbackAsync(
+            context,
+            serviceTier,
+            config.GoogleAiApiKey,
+            ct);
+        var imageRequest = await BuildImageRequestAsync(
+            context,
+            promptResult.PromptSelection,
+            promptResult.ImagePrompt,
+            ct);
+        var imageServiceTier = serviceTier == GoogleAiServiceTier.Flex
+                               && promptResult.ServiceTier == GoogleAiServiceTier.Flex
+            ? GoogleAiServiceTier.Flex
+            : GoogleAiServiceTier.Standard;
+
+        return await GenerateImageWithFallbackAsync(
+            context,
+            promptResult.ImagePrompt,
+            imageRequest,
+            imageServiceTier,
+            config.GoogleAiApiKey,
+            ct);
+    }
+
+    private async Task<PromptSelectionResult> GeneratePromptSelectionWithFallbackAsync(
+        PromptContext context,
+        GoogleAiServiceTier serviceTier,
+        string apiKey,
+        CancellationToken ct)
+    {
+        if (serviceTier != GoogleAiServiceTier.Flex)
+            return await GeneratePromptSelectionAsync(context, GoogleAiServiceTier.Standard, apiKey, ct);
+
+        try
+        {
+            return await ExecuteFlexWithRetriesAsync(
+                () => GeneratePromptSelectionAsync(context, GoogleAiServiceTier.Flex, apiKey, ct),
+                "画像プロンプト生成",
+                ct);
+        }
+        catch (Exception ex) when (IsRetryableFlexFailure(ex, ct))
+        {
+            logger.LogWarning(ex, "画像プロンプト生成の Flex 呼び出しが規定回数失敗したため Standard モードで再試行します。");
+            return await GeneratePromptSelectionAsync(context, GoogleAiServiceTier.Standard, apiKey, ct);
+        }
+    }
+
+    private async Task<PromptSelectionResult> GeneratePromptSelectionAsync(
+        PromptContext context,
+        GoogleAiServiceTier serviceTier,
+        string apiKey,
+        CancellationToken ct)
+    {
         // ステップ1: テキストモデルで詳細な画像プロンプトを生成（Google検索グラウンディングを有効化）
-        var textModel = new GenerativeModelEx(config.GoogleAiApiKey, TextModelName, httpClient: geminiHttpClient)
+        var textModel = new GenerativeModelEx(apiKey, TextModelName, httpClient: geminiHttpClient)
         {
             UseGoogleSearch = true,
             UseJsonMode = true,
@@ -73,7 +108,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         promptRequest.UseJsonMode<PromptSelectionResponse>(JsonSerializerOptions);
         promptRequest.AddText(contextPrompt);
 
-        var promptResponse = await GenerateContentAsync(textModel, promptRequest, serviceTier, config.GoogleAiApiKey, ct);
+        var promptResponse = await GenerateContentAsync(textModel, promptRequest, serviceTier, apiKey, ct);
         var promptSelection = promptResponse.ToObject<PromptSelectionResponse>(JsonSerializerOptions);
         if (promptSelection == null || string.IsNullOrWhiteSpace(promptSelection.ImagePrompt))
             throw new InvalidOperationException("Google AI returned an invalid structured prompt response.");
@@ -85,6 +120,62 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
             .ToList();
         var imagePrompt = promptSelection.ImagePrompt.Trim();
 
+        return new PromptSelectionResult(promptSelection, imagePrompt, serviceTier);
+    }
+
+    private async Task<GeneratedImageInfo> GenerateImageWithFallbackAsync(
+        PromptContext context,
+        string imagePrompt,
+        GenerateContentRequest imageRequest,
+        GoogleAiServiceTier serviceTier,
+        string apiKey,
+        CancellationToken ct)
+    {
+        if (serviceTier != GoogleAiServiceTier.Flex)
+        {
+            return await GenerateImageAsync(
+                context,
+                imagePrompt,
+                CloneGenerateContentRequest(imageRequest),
+                GoogleAiServiceTier.Standard,
+                apiKey,
+                ct);
+        }
+
+        try
+        {
+            return await ExecuteFlexWithRetriesAsync(
+                () => GenerateImageAsync(
+                    context,
+                    imagePrompt,
+                    CloneGenerateContentRequest(imageRequest),
+                    GoogleAiServiceTier.Flex,
+                    apiKey,
+                    ct),
+                "画像生成",
+                ct);
+        }
+        catch (Exception ex) when (IsRetryableFlexFailure(ex, ct))
+        {
+            logger.LogWarning(ex, "画像生成の Flex 呼び出しが規定回数失敗したため、生成済みプロンプトを使って Standard モードで再試行します。");
+            return await GenerateImageAsync(
+                context,
+                imagePrompt,
+                CloneGenerateContentRequest(imageRequest),
+                GoogleAiServiceTier.Standard,
+                apiKey,
+                ct);
+        }
+    }
+
+    private async Task<GeneratedImageInfo> GenerateImageAsync(
+        PromptContext context,
+        string imagePrompt,
+        GenerateContentRequest imageRequest,
+        GoogleAiServiceTier serviceTier,
+        string apiKey,
+        CancellationToken ct)
+    {
         // ステップ2: 画像モデルでアスペクト比・サイズを指定して壁紙を生成
         var displayInfo = DisplayHelper.GetDisplayInfo();
         var genConfig = new GenerationConfig
@@ -96,11 +187,35 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
                 ImageSize = displayInfo.ImageSize,
             }
         };
-        var imageModel = new GenerativeModelEx(config.GoogleAiApiKey, ImageModelName, genConfig, httpClient: geminiHttpClient)
+        var imageModel = new GenerativeModelEx(apiKey, ImageModelName, genConfig, httpClient: geminiHttpClient)
         {
             UseGoogleSearch = true,
         };
 
+        var response = await GenerateContentAsync(imageModel, imageRequest, serviceTier, apiKey, ct);
+
+        var imageBytes = ExtractImageBytes(response);
+
+        if (imageBytes == null || imageBytes.Length == 0)
+            throw new InvalidOperationException("No image data returned from Google AI.");
+
+        var filePath = FileNameHelper.GetImageFilePath(FixedImageSavePath);
+        await File.WriteAllBytesAsync(filePath, imageBytes, ct);
+
+        return new GeneratedImageInfo(
+            FilePath: filePath,
+            GeneratedAt: DateTime.Now,
+            UsedPrompt: imagePrompt,
+            ServiceTier: serviceTier,
+            SourceContext: context);
+    }
+
+    private async Task<GenerateContentRequest> BuildImageRequestAsync(
+        PromptContext context,
+        PromptSelectionResponse promptSelection,
+        string imagePrompt,
+        CancellationToken ct)
+    {
         // テキストモデルが採用したニュースだけ、そのOGP画像を参照画像として添付する
         var selectedNewsIds = promptSelection.SelectedNewsIds.ToHashSet(StringComparer.Ordinal);
         var ogpUrls = (context.NewsTopics ?? [])
@@ -159,22 +274,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
             }
         }
 
-        var response = await GenerateContentAsync(imageModel, imageRequest, serviceTier, config.GoogleAiApiKey, ct);
-
-        var imageBytes = ExtractImageBytes(response);
-
-        if (imageBytes == null || imageBytes.Length == 0)
-            throw new InvalidOperationException("No image data returned from Google AI.");
-
-        var filePath = FileNameHelper.GetImageFilePath(FixedImageSavePath);
-        await File.WriteAllBytesAsync(filePath, imageBytes, ct);
-
-        return new GeneratedImageInfo(
-            FilePath: filePath,
-            GeneratedAt: DateTime.Now,
-            UsedPrompt: imagePrompt,
-            ServiceTier: serviceTier,
-            SourceContext: context);
+        return imageRequest;
     }
 
     private async Task<GenerateContentResponse> GenerateContentAsync(
@@ -224,6 +324,68 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
             TypesSerializerContext.Default.GenerateContentResponse)
             ?? throw new InvalidOperationException("Google AI returned an empty response.");
     }
+
+    private async Task<T> ExecuteFlexWithRetriesAsync<T>(
+        Func<Task<T>> action,
+        string operationName,
+        CancellationToken ct)
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                return await action();
+            }
+            catch (Exception ex) when (attempt < MaxFlexAttempts && IsRetryableFlexFailure(ex, ct))
+            {
+                var delay = GetFlexRetryDelay(attempt);
+                logger.LogWarning(
+                    ex,
+                    "{OperationName} の Flex 呼び出しに失敗しました ({Attempt}/{MaxAttempts})。{DelaySeconds} 秒後に再試行します。",
+                    operationName,
+                    attempt,
+                    MaxFlexAttempts,
+                    delay.TotalSeconds);
+                await Task.Delay(delay, ct);
+            }
+        }
+    }
+
+    private static GenerateContentRequest CloneGenerateContentRequest(GenerateContentRequest request)
+    {
+        var json = JsonSerializer.Serialize(
+            request,
+            TypesSerializerContext.Default.GenerateContentRequest);
+        return JsonSerializer.Deserialize(
+            json,
+            TypesSerializerContext.Default.GenerateContentRequest)
+            ?? throw new InvalidOperationException("Failed to clone Google AI request.");
+    }
+
+    private static bool IsRetryableFlexFailure(Exception ex, CancellationToken ct)
+    {
+        if (ct.IsCancellationRequested)
+            return false;
+
+        if (ex is TaskCanceledException or TimeoutException)
+            return true;
+
+        return ex is HttpRequestException
+        {
+            StatusCode: HttpStatusCode.TooManyRequests
+                        or HttpStatusCode.InternalServerError
+                        or HttpStatusCode.ServiceUnavailable
+                        or HttpStatusCode.GatewayTimeout
+        };
+    }
+
+    private static TimeSpan GetFlexRetryDelay(int attempt)
+        => attempt switch
+        {
+            1 => TimeSpan.FromSeconds(2),
+            2 => TimeSpan.FromSeconds(5),
+            _ => TimeSpan.FromSeconds(10),
+        };
 
     private static string BuildGenerateContentUrl(string? model, string apiKey)
     {
@@ -363,4 +525,9 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
 
         public required List<string> SelectedNewsIds { get; set; }
     }
+
+    private sealed record PromptSelectionResult(
+        PromptSelectionResponse PromptSelection,
+        string ImagePrompt,
+        GoogleAiServiceTier ServiceTier);
 }

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -46,25 +46,9 @@ public class GoogleAiService(
         if (string.IsNullOrWhiteSpace(config.GoogleAiApiKey))
             throw new InvalidOperationException("Google AI API key is not configured.");
 
-        var promptResult = await GeneratePromptSelectionWithFallbackAsync(
-            context,
-            serviceTier,
-            config.GoogleAiApiKey,
-            ct);
-        var imagePrompt = promptResult.PromptSelection.ImagePrompt;
-        var imageRequest = await BuildImageRequestAsync(
-            context,
-            promptResult.PromptSelection,
-            imagePrompt,
-            ct);
-
-        return await GenerateImageWithFallbackAsync(
-            context,
-            imagePrompt,
-            imageRequest,
-            promptResult.ServiceTier,
-            config.GoogleAiApiKey,
-            ct);
+        var promptResult = await GeneratePromptSelectionWithFallbackAsync(context, serviceTier, config.GoogleAiApiKey, ct).ConfigureAwait(false);
+        var imageRequest = await BuildImageRequestAsync(context, promptResult.PromptSelection, ct).ConfigureAwait(false);
+        return await GenerateImageWithFallbackAsync(context, promptResult.PromptSelection.ImagePrompt, imageRequest, promptResult.ServiceTier, config.GoogleAiApiKey, ct).ConfigureAwait(false);
     }
 
     private async Task<PromptSelectionResult> GeneratePromptSelectionWithFallbackAsync(
@@ -74,16 +58,16 @@ public class GoogleAiService(
         CancellationToken ct)
     {
         if (serviceTier != GoogleAiServiceTier.Flex)
-            return await GeneratePromptSelectionAsync(context, GoogleAiServiceTier.Standard, apiKey, ct);
+            return await GeneratePromptSelectionAsync(context, GoogleAiServiceTier.Standard, apiKey, ct).ConfigureAwait(false);
 
         try
         {
-            return await GeneratePromptSelectionAsync(context, GoogleAiServiceTier.Flex, apiKey, ct);
+            return await GeneratePromptSelectionAsync(context, GoogleAiServiceTier.Flex, apiKey, ct).ConfigureAwait(false);
         }
         catch (Exception ex) when (!ct.IsCancellationRequested)
         {
             logger.LogWarning(ex, "画像プロンプト生成の Flex 呼び出しが規定回数失敗したため Standard モードで再試行します。");
-            return await GeneratePromptSelectionAsync(context, GoogleAiServiceTier.Standard, apiKey, ct);
+            return await GeneratePromptSelectionAsync(context, GoogleAiServiceTier.Standard, apiKey, ct).ConfigureAwait(false);
         }
     }
 
@@ -135,35 +119,17 @@ public class GoogleAiService(
     {
         if (serviceTier != GoogleAiServiceTier.Flex)
         {
-            return await GenerateImageAsync(
-                context,
-                imagePrompt,
-                imageRequest,
-                GoogleAiServiceTier.Standard,
-                apiKey,
-                ct);
+            return await GenerateImageAsync(context, imagePrompt, imageRequest, GoogleAiServiceTier.Standard, apiKey, ct).ConfigureAwait(false);
         }
 
         try
         {
-            return await GenerateImageAsync(
-                context,
-                imagePrompt,
-                imageRequest,
-                GoogleAiServiceTier.Flex,
-                apiKey,
-                ct);
+            return await GenerateImageAsync(context, imagePrompt, imageRequest, GoogleAiServiceTier.Flex, apiKey, ct).ConfigureAwait(false);
         }
         catch (Exception ex) when (!ct.IsCancellationRequested)
         {
             logger.LogWarning(ex, "画像生成の Flex 呼び出しが規定回数失敗したため、生成済みプロンプトを使って Standard モードで再試行します。");
-            return await GenerateImageAsync(
-                context,
-                imagePrompt,
-                imageRequest,
-                GoogleAiServiceTier.Standard,
-                apiKey,
-                ct);
+            return await GenerateImageAsync(context, imagePrompt, imageRequest, GoogleAiServiceTier.Standard, apiKey, ct).ConfigureAwait(false);
         }
     }
 
@@ -181,7 +147,7 @@ public class GoogleAiService(
         GenerateContentResponse response;
         try
         {
-            response = await imageModel.GenerateContentAsync(imageRequest, ct);
+            response = await imageModel.GenerateContentAsync(imageRequest, ct).ConfigureAwait(false);
         }
         catch (ApiException ex) when (IsPaidTierRequiredError(ex))
         {
@@ -194,21 +160,12 @@ public class GoogleAiService(
             throw new InvalidOperationException("No image data returned from Google AI.");
 
         var filePath = FileNameHelper.GetImageFilePath(FixedImageSavePath);
-        await File.WriteAllBytesAsync(filePath, imageBytes, ct);
+        await File.WriteAllBytesAsync(filePath, imageBytes, ct).ConfigureAwait(false);
 
-        return new GeneratedImageInfo(
-            FilePath: filePath,
-            GeneratedAt: DateTime.Now,
-            UsedPrompt: imagePrompt,
-            ServiceTier: serviceTier,
-            SourceContext: context);
+        return new(filePath, DateTime.Now, imagePrompt, serviceTier, context);
     }
 
-    private async Task<GenerateContentRequest> BuildImageRequestAsync(
-        PromptContext context,
-        PromptSelectionResponse promptSelection,
-        string imagePrompt,
-        CancellationToken ct)
+    private async Task<GenerateContentRequest> BuildImageRequestAsync(PromptContext context, PromptSelectionResponse promptSelection, CancellationToken ct)
     {
         // テキストモデルが採用したニュースだけ、そのOGP画像を参照画像として添付する
         var selectedNewsIds = promptSelection.SelectedNewsIds.ToHashSet(StringComparer.Ordinal);
@@ -219,18 +176,18 @@ public class GoogleAiService(
             .ToList();
         var finalPrompt = ogpUrls.Count > 0
             ? $$"""
-              {{imagePrompt}}
+              {{promptSelection.ImagePrompt}}
 
               Reference images from the selected news topics are attached. Incorporate their visual themes, color palette, and subject matter into the wallpaper design.
               """
-            : imagePrompt;
+            : promptSelection.ImagePrompt;
 
         var imageRequest = new GenerateContentRequest();
 
         // ベース壁紙がある場合はインラインデータとして先頭に付加し、プロンプトにも指示を追加
         if (!string.IsNullOrEmpty(context.BaseImagePath) && File.Exists(context.BaseImagePath))
         {
-            var baseImageBytes = await File.ReadAllBytesAsync(context.BaseImagePath, ct);
+            var baseImageBytes = await File.ReadAllBytesAsync(context.BaseImagePath, ct).ConfigureAwait(false);
             var baseMimeType = GetMimeTypeFromPath(context.BaseImagePath);
             imageRequest.AddInlineData(Convert.ToBase64String(baseImageBytes), baseMimeType);
             // ベース画像を参照しつつ、現在のテーマに合わない要素を整理する指示を追加
@@ -256,10 +213,10 @@ public class GoogleAiService(
             try
             {
                 // HTTPレスポンスからMIMEタイプを取得してインラインデータとして添付
-                using var imgResponse = await ogpHttpClient.GetAsync(imgUrl, ct);
+                using var imgResponse = await ogpHttpClient.GetAsync(imgUrl, ct).ConfigureAwait(false);
                 imgResponse.EnsureSuccessStatusCode();
                 var mimeType = imgResponse.Content.Headers.ContentType?.MediaType ?? "image/jpeg";
-                var imgBytes = await imgResponse.Content.ReadAsByteArrayAsync(ct);
+                var imgBytes = await imgResponse.Content.ReadAsByteArrayAsync(ct).ConfigureAwait(false);
                 imageRequest.AddInlineData(Convert.ToBase64String(imgBytes), mimeType);
             }
             catch (Exception ex)

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -51,15 +51,16 @@ public class GoogleAiService(
             serviceTier,
             config.GoogleAiApiKey,
             ct);
+        var imagePrompt = promptResult.PromptSelection.ImagePrompt;
         var imageRequest = await BuildImageRequestAsync(
             context,
             promptResult.PromptSelection,
-            promptResult.ImagePrompt,
+            imagePrompt,
             ct);
 
         return await GenerateImageWithFallbackAsync(
             context,
-            promptResult.ImagePrompt,
+            imagePrompt,
             imageRequest,
             promptResult.ServiceTier,
             config.GoogleAiApiKey,
@@ -119,9 +120,9 @@ public class GoogleAiService(
             .Select(id => id.Trim())
             .Distinct(StringComparer.Ordinal)
             .ToList();
-        var imagePrompt = promptSelection.ImagePrompt.Trim();
+        promptSelection.ImagePrompt = promptSelection.ImagePrompt.Trim();
 
-        return new PromptSelectionResult(promptSelection, imagePrompt, serviceTier);
+        return new PromptSelectionResult(promptSelection, serviceTier);
     }
 
     private async Task<GeneratedImageInfo> GenerateImageWithFallbackAsync(
@@ -137,7 +138,7 @@ public class GoogleAiService(
             return await GenerateImageAsync(
                 context,
                 imagePrompt,
-                CloneGenerateContentRequest(imageRequest),
+                imageRequest,
                 GoogleAiServiceTier.Standard,
                 apiKey,
                 ct);
@@ -148,7 +149,7 @@ public class GoogleAiService(
             return await GenerateImageAsync(
                 context,
                 imagePrompt,
-                CloneGenerateContentRequest(imageRequest),
+                imageRequest,
                 GoogleAiServiceTier.Flex,
                 apiKey,
                 ct);
@@ -159,7 +160,7 @@ public class GoogleAiService(
             return await GenerateImageAsync(
                 context,
                 imagePrompt,
-                CloneGenerateContentRequest(imageRequest),
+                imageRequest,
                 GoogleAiServiceTier.Standard,
                 apiKey,
                 ct);
@@ -280,17 +281,6 @@ public class GoogleAiService(
         AddGoogleSearchTool(imageRequest);
 
         return imageRequest;
-    }
-
-    private static GenerateContentRequest CloneGenerateContentRequest(GenerateContentRequest request)
-    {
-        var json = JsonSerializer.Serialize(
-            request,
-            TypesSerializerContext.Default.GenerateContentRequest);
-        return JsonSerializer.Deserialize(
-            json,
-            TypesSerializerContext.Default.GenerateContentRequest)
-            ?? throw new InvalidOperationException("Failed to clone Google AI request.");
     }
 
     private static void AddGoogleSearchTool(GenerateContentRequest request)
@@ -417,14 +407,13 @@ public class GoogleAiService(
 
     private sealed class PromptSelectionResponse
     {
-        public required string ImagePrompt { get; init; }
+        public required string ImagePrompt { get; set; }
 
         public required List<string> SelectedNewsIds { get; set; }
     }
 
     private sealed record PromptSelectionResult(
         PromptSelectionResponse PromptSelection,
-        string ImagePrompt,
         GoogleAiServiceTier ServiceTier);
 
     private static bool IsPaidTierRequiredError(ApiException ex)

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -1,6 +1,10 @@
+using System.Globalization;
 using System.IO;
+using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using GenerativeAI;
 using GenerativeAI.Types;
 using Microsoft.Extensions.Logging;
@@ -12,7 +16,12 @@ namespace WondayWall.Services;
 
 public class GoogleAiService(AppConfigService configService, IHttpClientFactory httpClientFactory, ILogger<GoogleAiService> logger)
 {
-    private readonly HttpClient httpClient = httpClientFactory.CreateClient("WondayWall");
+    private const string TextModelName = "gemini-3-flash-preview";
+    private const string ImageModelName = "gemini-3.1-flash-image-preview";
+    private const int FlexServerTimeoutSeconds = 600;
+
+    private readonly HttpClient ogpHttpClient = httpClientFactory.CreateClient("WondayWall");
+    private readonly HttpClient geminiHttpClient = httpClientFactory.CreateClient("Gemini");
     private static readonly string FixedImageSavePath = Path.Combine(
         System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData),
         "WondayWall", "wallpapers");
@@ -26,7 +35,27 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
 
     public async Task<GeneratedImageInfo> GenerateWallpaperAsync(
         PromptContext context,
+        GoogleAiServiceTier serviceTier,
         CancellationToken ct = default)
+    {
+        if (serviceTier != GoogleAiServiceTier.Flex)
+            return await GenerateWallpaperCoreAsync(context, GoogleAiServiceTier.Standard, ct);
+
+        try
+        {
+            return await GenerateWallpaperCoreAsync(context, GoogleAiServiceTier.Flex, ct);
+        }
+        catch (Exception ex) when (!ct.IsCancellationRequested)
+        {
+            logger.LogWarning(ex, "Flex モードの Google AI 生成に失敗したため Standard モードで再試行します。");
+            return await GenerateWallpaperCoreAsync(context, GoogleAiServiceTier.Standard, ct);
+        }
+    }
+
+    private async Task<GeneratedImageInfo> GenerateWallpaperCoreAsync(
+        PromptContext context,
+        GoogleAiServiceTier serviceTier,
+        CancellationToken ct)
     {
         var config = configService.Current;
 
@@ -34,7 +63,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
             throw new InvalidOperationException("Google AI API key is not configured.");
 
         // ステップ1: テキストモデルで詳細な画像プロンプトを生成（Google検索グラウンディングを有効化）
-        var textModel = new GenerativeModelEx(config.GoogleAiApiKey, "gemini-3-flash-preview")
+        var textModel = new GenerativeModelEx(config.GoogleAiApiKey, TextModelName, httpClient: geminiHttpClient)
         {
             UseGoogleSearch = true,
             UseJsonMode = true,
@@ -44,7 +73,8 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         promptRequest.UseJsonMode<PromptSelectionResponse>(JsonSerializerOptions);
         promptRequest.AddText(contextPrompt);
 
-        var promptSelection = await textModel.GenerateObjectAsync<PromptSelectionResponse>(promptRequest, ct);
+        var promptResponse = await GenerateContentAsync(textModel, promptRequest, serviceTier, config.GoogleAiApiKey, ct);
+        var promptSelection = promptResponse.ToObject<PromptSelectionResponse>(JsonSerializerOptions);
         if (promptSelection == null || string.IsNullOrWhiteSpace(promptSelection.ImagePrompt))
             throw new InvalidOperationException("Google AI returned an invalid structured prompt response.");
 
@@ -66,7 +96,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
                 ImageSize = displayInfo.ImageSize,
             }
         };
-        var imageModel = new GenerativeModel(config.GoogleAiApiKey, "gemini-3.1-flash-image-preview", genConfig)
+        var imageModel = new GenerativeModelEx(config.GoogleAiApiKey, ImageModelName, genConfig, httpClient: geminiHttpClient)
         {
             UseGoogleSearch = true,
         };
@@ -117,7 +147,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
             try
             {
                 // HTTPレスポンスからMIMEタイプを取得してインラインデータとして添付
-                using var imgResponse = await httpClient.GetAsync(imgUrl, ct);
+                using var imgResponse = await ogpHttpClient.GetAsync(imgUrl, ct);
                 imgResponse.EnsureSuccessStatusCode();
                 var mimeType = imgResponse.Content.Headers.ContentType?.MediaType ?? "image/jpeg";
                 var imgBytes = await imgResponse.Content.ReadAsByteArrayAsync(ct);
@@ -129,7 +159,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
             }
         }
 
-        var response = await imageModel.GenerateContentAsync(imageRequest, cancellationToken: ct);
+        var response = await GenerateContentAsync(imageModel, imageRequest, serviceTier, config.GoogleAiApiKey, ct);
 
         var imageBytes = ExtractImageBytes(response);
 
@@ -143,7 +173,78 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
             FilePath: filePath,
             GeneratedAt: DateTime.Now,
             UsedPrompt: imagePrompt,
+            ServiceTier: serviceTier,
             SourceContext: context);
+    }
+
+    private async Task<GenerateContentResponse> GenerateContentAsync(
+        GenerativeModelEx model,
+        GenerateContentRequest request,
+        GoogleAiServiceTier serviceTier,
+        string apiKey,
+        CancellationToken ct)
+    {
+        if (serviceTier == GoogleAiServiceTier.Standard)
+            return await model.GenerateContentAsync(request, cancellationToken: ct);
+
+        model.PrepareRequestForGenerateContent(request);
+
+        var requestNode = JsonSerializer.SerializeToNode(
+            request,
+            TypesSerializerContext.Default.GenerateContentRequest);
+        if (requestNode is not JsonObject requestObject)
+            throw new InvalidOperationException("Failed to build Google AI request JSON.");
+
+        requestObject["service_tier"] = "flex";
+
+        using var httpRequest = new HttpRequestMessage(
+            HttpMethod.Post,
+            BuildGenerateContentUrl(model.Model, apiKey));
+        httpRequest.Headers.TryAddWithoutValidation(
+            "X-Server-Timeout",
+            FlexServerTimeoutSeconds.ToString(CultureInfo.InvariantCulture));
+        httpRequest.Content = new StringContent(
+            requestObject.ToJsonString(JsonSerializerOptions),
+            Encoding.UTF8,
+            "application/json");
+
+        using var response = await geminiHttpClient.SendAsync(
+            httpRequest,
+            HttpCompletionOption.ResponseHeadersRead,
+            ct);
+        var responseJson = await response.Content.ReadAsStringAsync(ct);
+        if (!response.IsSuccessStatusCode)
+            throw new HttpRequestException(
+                BuildGoogleAiErrorMessage(response.StatusCode, response.ReasonPhrase, responseJson),
+                inner: null,
+                response.StatusCode);
+
+        return JsonSerializer.Deserialize(
+            responseJson,
+            TypesSerializerContext.Default.GenerateContentResponse)
+            ?? throw new InvalidOperationException("Google AI returned an empty response.");
+    }
+
+    private static string BuildGenerateContentUrl(string? model, string apiKey)
+    {
+        if (string.IsNullOrWhiteSpace(model))
+            throw new InvalidOperationException("Google AI model is not configured.");
+
+        var normalizedModel = model.StartsWith("models/", StringComparison.Ordinal)
+            ? model
+            : $"models/{model}";
+        return $"https://generativelanguage.googleapis.com/v1beta/{normalizedModel}:generateContent?key={Uri.EscapeDataString(apiKey)}";
+    }
+
+    private static string BuildGoogleAiErrorMessage(HttpStatusCode statusCode, string? reasonPhrase, string responseBody)
+    {
+        var trimmedBody = string.IsNullOrWhiteSpace(responseBody)
+            ? "No response body."
+            : responseBody.Trim();
+        if (trimmedBody.Length > 500)
+            trimmedBody = $"{trimmedBody[..500]}...";
+
+        return $"Google AI request failed ({(int)statusCode} {reasonPhrase}): {trimmedBody}";
     }
 
     /// <summary>

--- a/WondayWall/Services/TaskSchedulerService.cs
+++ b/WondayWall/Services/TaskSchedulerService.cs
@@ -20,7 +20,8 @@ public class TaskSchedulerService(AppConfigService appConfigService)
 
         using var ts = new TaskService();
         var td = ts.NewTask();
-        td.RegistrationInfo.Description = $"WondayWall 壁紙自動生成 ({ScheduleHelper.FormatSlotTimes(runsPerDay)} + ログオン時補完)";
+        td.RegistrationInfo.Description =
+            $"WondayWall の定期壁紙更新タスクです ({ScheduleHelper.FormatSlotTimes(runsPerDay)} + ログオン時補完)。バックグラウンド実行用のため Google AI の画像生成を Flex モードで実行し、Flex が失敗した場合は Standard にフォールバックします。実行時点の予定・ニュースを取得してから画像生成し、完了後に壁紙へ適用します。";
 
         var dailyTrigger = new DailyTrigger
         {

--- a/WondayWall/Views/MainWindow.xaml
+++ b/WondayWall/Views/MainWindow.xaml
@@ -124,6 +124,10 @@
                                             DisplayMemberBinding="{Binding IsSuccess}"
                                             Header="成功" />
                                         <GridViewColumn
+                                            Width="80"
+                                            DisplayMemberBinding="{Binding ServiceTier}"
+                                            Header="AI" />
+                                        <GridViewColumn
                                             Width="60"
                                             DisplayMemberBinding="{Binding UsedCalendarEvents.Count, FallbackValue=0}"
                                             Header="予定" />

--- a/WondayWall/WondayWall.csproj
+++ b/WondayWall/WondayWall.csproj
@@ -33,12 +33,12 @@
     <PackageReference Include="Kamishibai.Hosting" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
     <PackageReference Include="System.ServiceModel.Syndication" Version="10.0.5" />
     <PackageReference Include="Slions.VirtualDesktop.WPF" Version="6.9.2" />
     <PackageReference Include="WPF-UI" Version="4.2.0" />
     <PackageReference Include="TaskScheduler" Version="2.*" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.*" PrivateAssets="all" />
     <PackageReference Include="OpenGraph-Net" Version="4.0.1" />
-    <PackageReference Include="Polly.Extensions" Version="8.6.6" />
   </ItemGroup>
 </Project>

--- a/WondayWall/WondayWall.csproj
+++ b/WondayWall/WondayWall.csproj
@@ -39,6 +39,6 @@
     <PackageReference Include="TaskScheduler" Version="2.*" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.*" PrivateAssets="all" />
     <PackageReference Include="OpenGraph-Net" Version="4.0.1" />
-    <PackageReference Include="Polly" Version="8.6.6" />
+    <PackageReference Include="Polly.Extensions" Version="8.6.6" />
   </ItemGroup>
 </Project>

--- a/WondayWall/WondayWall.csproj
+++ b/WondayWall/WondayWall.csproj
@@ -39,5 +39,6 @@
     <PackageReference Include="TaskScheduler" Version="2.*" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.*" PrivateAssets="all" />
     <PackageReference Include="OpenGraph-Net" Version="4.0.1" />
+    <PackageReference Include="Polly" Version="8.6.6" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## 概要

- 手動生成 / `generate` / `check-google-ai` は Google AI の Standard 呼び出しを使うようにしました
- `run-once` の定期実行では Flex 呼び出しを使い、429 / 503 / timeout などの一時エラーは Polly で最大 3 回まで Flex 再試行してから Standard にフォールバックするようにしました
- 画像生成プロンプトの出力後に画像生成だけ Flex 失敗した場合は、プロンプト生成をやり直さず、生成済みプロンプトを使って画像生成のみ Standard でフォールバックします
- 実行履歴と履歴 UI に使用した呼び出し tier を残し、Task Scheduler の説明にも Flex 実行を明記しました

## 確認

- `dotnet restore WondayWall\WondayWall.csproj`
- `dotnet build WondayWall\WondayWall.csproj --no-restore`
- `git diff --check`
- Batch API を使っていないことを静的確認