### PR TITLE
[codex] Google AI APIキー案内と無料枠エラー表示を追加

### DIFF
--- a/WondayWall/Program.cs
+++ b/WondayWall/Program.cs
@@ -45,9 +45,8 @@ static void ConfigureCommonServices(IServiceCollection services)
 {
     services.AddLogging(b => b.AddConsole());
     services.AddHttpClient("WondayWall", c => c.Timeout = TimeSpan.FromSeconds(30));
-    services.AddTransient<GoogleAiErrorMessageHandler>();
     services.AddHttpClient(GoogleAiService.GoogleAiHttpClientName)
-        .AddHttpMessageHandler<GoogleAiErrorMessageHandler>();
+        .AddHttpMessageHandler(static () => new GoogleAiErrorMessageHandler());
     services.AddSingleton<WallpaperService>();
     services.AddSingleton<AppConfigService>();
     services.AddSingleton<HistoryService>();

--- a/WondayWall/Program.cs
+++ b/WondayWall/Program.cs
@@ -45,6 +45,12 @@ static void ConfigureCommonServices(IServiceCollection services)
 {
     services.AddLogging(b => b.AddConsole());
     services.AddHttpClient("WondayWall", c => c.Timeout = TimeSpan.FromSeconds(30));
+    services.AddTransient<GoogleAiPromptErrorMessageHandler>();
+    services.AddTransient<GoogleAiImageErrorMessageHandler>();
+    services.AddHttpClient(GoogleAiService.PromptHttpClientName)
+        .AddHttpMessageHandler<GoogleAiPromptErrorMessageHandler>();
+    services.AddHttpClient(GoogleAiService.ImageHttpClientName)
+        .AddHttpMessageHandler<GoogleAiImageErrorMessageHandler>();
     services.AddSingleton<WallpaperService>();
     services.AddSingleton<AppConfigService>();
     services.AddSingleton<HistoryService>();

--- a/WondayWall/Program.cs
+++ b/WondayWall/Program.cs
@@ -45,7 +45,6 @@ static void ConfigureCommonServices(IServiceCollection services)
 {
     services.AddLogging(b => b.AddConsole());
     services.AddHttpClient("WondayWall", c => c.Timeout = TimeSpan.FromSeconds(30));
-    services.AddHttpClient(GoogleAiService.GoogleAiHttpClientName);
     services.AddSingleton<WallpaperService>();
     services.AddSingleton<AppConfigService>();
     services.AddSingleton<HistoryService>();

--- a/WondayWall/Program.cs
+++ b/WondayWall/Program.cs
@@ -45,8 +45,7 @@ static void ConfigureCommonServices(IServiceCollection services)
 {
     services.AddLogging(b => b.AddConsole());
     services.AddHttpClient("WondayWall", c => c.Timeout = TimeSpan.FromSeconds(30));
-    services.AddHttpClient(GoogleAiService.GoogleAiHttpClientName)
-        .AddHttpMessageHandler(static () => new GoogleAiErrorMessageHandler());
+    services.AddHttpClient(GoogleAiService.GoogleAiHttpClientName);
     services.AddSingleton<WallpaperService>();
     services.AddSingleton<AppConfigService>();
     services.AddSingleton<HistoryService>();

--- a/WondayWall/Program.cs
+++ b/WondayWall/Program.cs
@@ -45,12 +45,9 @@ static void ConfigureCommonServices(IServiceCollection services)
 {
     services.AddLogging(b => b.AddConsole());
     services.AddHttpClient("WondayWall", c => c.Timeout = TimeSpan.FromSeconds(30));
-    services.AddTransient<GoogleAiPromptErrorMessageHandler>();
-    services.AddTransient<GoogleAiImageErrorMessageHandler>();
-    services.AddHttpClient(GoogleAiService.PromptHttpClientName)
-        .AddHttpMessageHandler<GoogleAiPromptErrorMessageHandler>();
-    services.AddHttpClient(GoogleAiService.ImageHttpClientName)
-        .AddHttpMessageHandler<GoogleAiImageErrorMessageHandler>();
+    services.AddTransient<GoogleAiErrorMessageHandler>();
+    services.AddHttpClient(GoogleAiService.GoogleAiHttpClientName)
+        .AddHttpMessageHandler<GoogleAiErrorMessageHandler>();
     services.AddSingleton<WallpaperService>();
     services.AddSingleton<AppConfigService>();
     services.AddSingleton<HistoryService>();

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using GenerativeAI;
@@ -13,6 +14,11 @@ namespace WondayWall.Services;
 public class GoogleAiService(AppConfigService configService, IHttpClientFactory httpClientFactory, ILogger<GoogleAiService> logger)
 {
     private readonly HttpClient httpClient = httpClientFactory.CreateClient("WondayWall");
+    private readonly HttpClient googleAiHttpClient = new(new GoogleAiErrorMessageHandler());
+    private const string GoogleAiApiKeyPageUrl = "https://aistudio.google.com/app/api-keys";
+    private const string PaidTierRequiredMessage =
+        "無料枠または課金未設定の Google AI API キーでは、この画像生成機能を利用できません。Google AI Studio で課金設定済みのプロジェクト/APIキーを確認してください: "
+        + GoogleAiApiKeyPageUrl;
     private static readonly string FixedImageSavePath = Path.Combine(
         System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData),
         "WondayWall", "wallpapers");
@@ -34,7 +40,11 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
             throw new InvalidOperationException("Google AI API key is not configured.");
 
         // ステップ1: テキストモデルで詳細な画像プロンプトを生成（Google検索グラウンディングを有効化）
-        var textModel = new GenerativeModelEx(config.GoogleAiApiKey, "gemini-3-flash-preview")
+        var textModel = new GenerativeModelEx(
+            config.GoogleAiApiKey,
+            "gemini-3-flash-preview",
+            httpClient: googleAiHttpClient,
+            logger: logger)
         {
             UseGoogleSearch = true,
             UseJsonMode = true,
@@ -66,7 +76,12 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
                 ImageSize = displayInfo.ImageSize,
             }
         };
-        var imageModel = new GenerativeModel(config.GoogleAiApiKey, "gemini-3.1-flash-image-preview", genConfig)
+        var imageModel = new GenerativeModel(
+            config.GoogleAiApiKey,
+            "gemini-3.1-flash-image-preview",
+            genConfig,
+            httpClient: googleAiHttpClient,
+            logger: logger)
         {
             UseGoogleSearch = true,
         };
@@ -261,5 +276,54 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         public required string ImagePrompt { get; init; }
 
         public required List<string> SelectedNewsIds { get; set; }
+    }
+
+    private sealed class GoogleAiErrorMessageHandler() : DelegatingHandler(new HttpClientHandler())
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = await base.SendAsync(request, cancellationToken);
+            if (response.StatusCode != HttpStatusCode.BadRequest || response.Content == null)
+                return response;
+
+            var originalContent = response.Content;
+            var contentBytes = await originalContent.ReadAsByteArrayAsync(cancellationToken);
+            var replacementContent = new ByteArrayContent(contentBytes);
+            foreach (var header in originalContent.Headers)
+                replacementContent.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            response.Content = replacementContent;
+            originalContent.Dispose();
+
+            if (!IsFailedPreconditionError(contentBytes))
+                return response;
+
+            response.Dispose();
+            throw new InvalidOperationException(PaidTierRequiredMessage);
+        }
+
+        private static bool IsFailedPreconditionError(byte[] contentBytes)
+        {
+            try
+            {
+                var apiError = JsonSerializer.Deserialize<GoogleApiErrorEnvelope>(contentBytes, JsonSerializerOptions);
+                return apiError?.Error is { Code: 400, Status: "FAILED_PRECONDITION" };
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        }
+    }
+
+    private sealed class GoogleApiErrorEnvelope
+    {
+        public GoogleApiError? Error { get; init; }
+    }
+
+    private sealed class GoogleApiError
+    {
+        public int Code { get; init; }
+
+        public string? Status { get; init; }
     }
 }

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -13,12 +13,12 @@ namespace WondayWall.Services;
 
 public class GoogleAiService(AppConfigService configService, IHttpClientFactory httpClientFactory, ILogger<GoogleAiService> logger)
 {
+    internal const string PromptHttpClientName = "GoogleAiPrompt";
+    internal const string ImageHttpClientName = "GoogleAiImage";
+
     private readonly HttpClient httpClient = httpClientFactory.CreateClient("WondayWall");
-    private readonly HttpClient googleAiHttpClient = new(new GoogleAiErrorMessageHandler());
-    private const string GoogleAiApiKeyPageUrl = "https://aistudio.google.com/app/api-keys";
-    private const string PaidTierRequiredMessage =
-        "無料枠または課金未設定の Google AI API キーでは、この画像生成機能を利用できません。Google AI Studio で課金設定済みのプロジェクト/APIキーを確認してください: "
-        + GoogleAiApiKeyPageUrl;
+    private readonly HttpClient googleAiPromptHttpClient = httpClientFactory.CreateClient(PromptHttpClientName);
+    private readonly HttpClient googleAiImageHttpClient = httpClientFactory.CreateClient(ImageHttpClientName);
     private static readonly string FixedImageSavePath = Path.Combine(
         System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData),
         "WondayWall", "wallpapers");
@@ -43,7 +43,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         var textModel = new GenerativeModelEx(
             config.GoogleAiApiKey,
             "gemini-3-flash-preview",
-            httpClient: googleAiHttpClient,
+            httpClient: googleAiPromptHttpClient,
             logger: logger)
         {
             UseGoogleSearch = true,
@@ -80,7 +80,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
             config.GoogleAiApiKey,
             "gemini-3.1-flash-image-preview",
             genConfig,
-            httpClient: googleAiHttpClient,
+            httpClient: googleAiImageHttpClient,
             logger: logger)
         {
             UseGoogleSearch = true,
@@ -278,52 +278,76 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         public required List<string> SelectedNewsIds { get; set; }
     }
 
-    private sealed class GoogleAiErrorMessageHandler() : DelegatingHandler(new HttpClientHandler())
+}
+
+internal sealed class GoogleAiPromptErrorMessageHandler()
+    : GoogleAiErrorMessageHandler(treatResourceExhaustedAsPaidTierRequired: true);
+
+internal sealed class GoogleAiImageErrorMessageHandler()
+    : GoogleAiErrorMessageHandler(treatResourceExhaustedAsPaidTierRequired: false);
+
+internal abstract class GoogleAiErrorMessageHandler(bool treatResourceExhaustedAsPaidTierRequired) : DelegatingHandler
+{
+    private const string GoogleAiApiKeyPageUrl = "https://aistudio.google.com/app/api-keys";
+    private const string PaidTierRequiredMessage =
+        "無料枠または課金未設定の Google AI API キーでは、この画像生成機能を利用できません。Google AI Studio で課金設定済みのプロジェクト/APIキーを確認してください: "
+        + GoogleAiApiKeyPageUrl;
+    private static readonly JsonSerializerOptions GoogleApiErrorJsonSerializerOptions = new()
     {
-        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        PropertyNameCaseInsensitive = true,
+    };
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var response = await base.SendAsync(request, cancellationToken);
+        if (!ShouldInspect(response.StatusCode) || response.Content == null)
+            return response;
+
+        var originalContent = response.Content;
+        var contentBytes = await originalContent.ReadAsByteArrayAsync(cancellationToken);
+        var replacementContent = new ByteArrayContent(contentBytes);
+        foreach (var header in originalContent.Headers)
+            replacementContent.Headers.TryAddWithoutValidation(header.Key, header.Value);
+        response.Content = replacementContent;
+        originalContent.Dispose();
+
+        if (!IsPaidTierRequiredError(contentBytes))
+            return response;
+
+        response.Dispose();
+        throw new InvalidOperationException(PaidTierRequiredMessage);
+    }
+
+    private bool ShouldInspect(HttpStatusCode statusCode)
+        => statusCode == HttpStatusCode.BadRequest
+            || (treatResourceExhaustedAsPaidTierRequired && statusCode == HttpStatusCode.TooManyRequests);
+
+    private bool IsPaidTierRequiredError(byte[] contentBytes)
+    {
+        try
         {
-            var response = await base.SendAsync(request, cancellationToken);
-            if (response.StatusCode != HttpStatusCode.BadRequest || response.Content == null)
-                return response;
-
-            var originalContent = response.Content;
-            var contentBytes = await originalContent.ReadAsByteArrayAsync(cancellationToken);
-            var replacementContent = new ByteArrayContent(contentBytes);
-            foreach (var header in originalContent.Headers)
-                replacementContent.Headers.TryAddWithoutValidation(header.Key, header.Value);
-            response.Content = replacementContent;
-            originalContent.Dispose();
-
-            if (!IsFailedPreconditionError(contentBytes))
-                return response;
-
-            response.Dispose();
-            throw new InvalidOperationException(PaidTierRequiredMessage);
+            var apiError = JsonSerializer.Deserialize<GoogleApiErrorEnvelope>(
+                contentBytes,
+                GoogleApiErrorJsonSerializerOptions);
+            return apiError?.Error is { Code: 400, Status: "FAILED_PRECONDITION" }
+                || (treatResourceExhaustedAsPaidTierRequired
+                    && apiError?.Error is { Code: 429, Status: "RESOURCE_EXHAUSTED" });
         }
-
-        private static bool IsFailedPreconditionError(byte[] contentBytes)
+        catch (JsonException)
         {
-            try
-            {
-                var apiError = JsonSerializer.Deserialize<GoogleApiErrorEnvelope>(contentBytes, JsonSerializerOptions);
-                return apiError?.Error is { Code: 400, Status: "FAILED_PRECONDITION" };
-            }
-            catch (JsonException)
-            {
-                return false;
-            }
+            return false;
         }
     }
+}
 
-    private sealed class GoogleApiErrorEnvelope
-    {
-        public GoogleApiError? Error { get; init; }
-    }
+internal sealed class GoogleApiErrorEnvelope
+{
+    public GoogleApiError? Error { get; init; }
+}
 
-    private sealed class GoogleApiError
-    {
-        public int Code { get; init; }
+internal sealed class GoogleApiError
+{
+    public int Code { get; init; }
 
-        public string? Status { get; init; }
-    }
+    public string? Status { get; init; }
 }

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -40,10 +40,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
             throw new InvalidOperationException("Google AI API key is not configured.");
 
         // ステップ1: テキストモデルで詳細な画像プロンプトを生成（Google検索グラウンディングを有効化）
-        var textModel = new GenerativeModelEx(
-            config.GoogleAiApiKey,
-            "gemini-3-flash-preview",
-            httpClient: httpClient)
+        var textModel = new GenerativeModelEx(config.GoogleAiApiKey, "gemini-3-flash-preview")
         {
             UseGoogleSearch = true,
             UseJsonMode = true,
@@ -84,11 +81,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
                 ImageSize = displayInfo.ImageSize,
             }
         };
-        var imageModel = new GenerativeModel(
-            config.GoogleAiApiKey,
-            "gemini-3.1-flash-image-preview",
-            genConfig,
-            httpClient: httpClient)
+        var imageModel = new GenerativeModel(config.GoogleAiApiKey, "gemini-3.1-flash-image-preview", genConfig)
         {
             UseGoogleSearch = true,
         };

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -43,8 +43,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         var textModel = new GenerativeModelEx(
             config.GoogleAiApiKey,
             "gemini-3-flash-preview",
-            httpClient: httpClient,
-            logger: logger)
+            httpClient: httpClient)
         {
             UseGoogleSearch = true,
             UseJsonMode = true,
@@ -89,8 +88,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
             config.GoogleAiApiKey,
             "gemini-3.1-flash-image-preview",
             genConfig,
-            httpClient: httpClient,
-            logger: logger)
+            httpClient: httpClient)
         {
             UseGoogleSearch = true,
         };

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -1,8 +1,8 @@
 using System.IO;
-using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using GenerativeAI;
+using GenerativeAI.Exceptions;
 using GenerativeAI.Types;
 using Microsoft.Extensions.Logging;
 using WondayWall.ComponentModel;
@@ -14,6 +14,10 @@ namespace WondayWall.Services;
 public class GoogleAiService(AppConfigService configService, IHttpClientFactory httpClientFactory, ILogger<GoogleAiService> logger)
 {
     internal const string GoogleAiHttpClientName = "GoogleAi";
+    private const string GoogleAiApiKeyPageUrl = "https://aistudio.google.com/app/api-keys";
+    private const string PaidTierRequiredMessage =
+        "無料枠または課金未設定の Google AI API キーでは、この画像生成機能を利用できません。Google AI Studio で課金設定済みのプロジェクト/APIキーを確認してください: "
+        + GoogleAiApiKeyPageUrl;
 
     private readonly HttpClient httpClient = httpClientFactory.CreateClient("WondayWall");
     private readonly HttpClient googleAiHttpClient = httpClientFactory.CreateClient(GoogleAiHttpClientName);
@@ -52,7 +56,16 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         promptRequest.UseJsonMode<PromptSelectionResponse>(JsonSerializerOptions);
         promptRequest.AddText(contextPrompt);
 
-        var promptSelection = await textModel.GenerateObjectAsync<PromptSelectionResponse>(promptRequest, ct);
+        PromptSelectionResponse? promptSelection;
+        try
+        {
+            promptSelection = await textModel.GenerateObjectAsync<PromptSelectionResponse>(promptRequest, ct);
+        }
+        catch (ApiException ex) when (IsPaidTierRequiredError(ex))
+        {
+            throw new InvalidOperationException(PaidTierRequiredMessage, ex);
+        }
+
         if (promptSelection == null || string.IsNullOrWhiteSpace(promptSelection.ImagePrompt))
             throw new InvalidOperationException("Google AI returned an invalid structured prompt response.");
 
@@ -142,7 +155,15 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
             }
         }
 
-        var response = await imageModel.GenerateContentAsync(imageRequest, cancellationToken: ct);
+        GenerateContentResponse response;
+        try
+        {
+            response = await imageModel.GenerateContentAsync(imageRequest, cancellationToken: ct);
+        }
+        catch (ApiException ex) when (IsPaidTierRequiredError(ex))
+        {
+            throw new InvalidOperationException(PaidTierRequiredMessage, ex);
+        }
 
         var imageBytes = ExtractImageBytes(response);
 
@@ -276,53 +297,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         public required List<string> SelectedNewsIds { get; set; }
     }
 
-}
-
-internal sealed class GoogleAiErrorMessageHandler : DelegatingHandler
-{
-    private const string GoogleAiApiKeyPageUrl = "https://aistudio.google.com/app/api-keys";
-    private const string PaidTierRequiredMessage =
-        "無料枠または課金未設定の Google AI API キーでは、この画像生成機能を利用できません。Google AI Studio で課金設定済みのプロジェクト/APIキーを確認してください: "
-        + GoogleAiApiKeyPageUrl;
-
-    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-    {
-        var response = await base.SendAsync(request, cancellationToken);
-        if (response.Content == null
-            || response.StatusCode is not (HttpStatusCode.BadRequest or HttpStatusCode.TooManyRequests))
-            return response;
-
-        var originalContent = response.Content;
-        var content = await originalContent.ReadAsStringAsync(cancellationToken);
-        response.Content = new StringContent(
-            content,
-            System.Text.Encoding.UTF8,
-            originalContent.Headers.ContentType?.MediaType ?? "application/json");
-        originalContent.Dispose();
-
-        if (!IsPaidTierRequiredError(content))
-            return response;
-
-        response.Dispose();
-        throw new InvalidOperationException(PaidTierRequiredMessage);
-    }
-
-    private static bool IsPaidTierRequiredError(string content)
-    {
-        try
-        {
-            using var document = JsonDocument.Parse(content);
-            return document.RootElement.TryGetProperty("error", out var error)
-                && error.TryGetProperty("code", out var code)
-                && error.TryGetProperty("status", out var status)
-                && code.TryGetInt32(out var errorCode)
-                && status.ValueKind == JsonValueKind.String
-                && (errorCode, status.GetString()) is (400, "FAILED_PRECONDITION")
-                    or (429, "RESOURCE_EXHAUSTED");
-        }
-        catch (JsonException)
-        {
-            return false;
-        }
-    }
+    private static bool IsPaidTierRequiredError(ApiException ex)
+        => ex is { ErrorCode: 400, ErrorStatus: "FAILED_PRECONDITION" }
+            or { ErrorCode: 429, ErrorStatus: "RESOURCE_EXHAUSTED" };
 }

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -284,61 +284,45 @@ internal sealed class GoogleAiErrorMessageHandler : DelegatingHandler
     private const string PaidTierRequiredMessage =
         "無料枠または課金未設定の Google AI API キーでは、この画像生成機能を利用できません。Google AI Studio で課金設定済みのプロジェクト/APIキーを確認してください: "
         + GoogleAiApiKeyPageUrl;
-    private static readonly JsonSerializerOptions GoogleApiErrorJsonSerializerOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-    };
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         var response = await base.SendAsync(request, cancellationToken);
-        if (!ShouldInspect(response.StatusCode) || response.Content == null)
+        if (response.Content == null
+            || response.StatusCode is not (HttpStatusCode.BadRequest or HttpStatusCode.TooManyRequests))
             return response;
 
         var originalContent = response.Content;
-        var contentBytes = await originalContent.ReadAsByteArrayAsync(cancellationToken);
-        var replacementContent = new ByteArrayContent(contentBytes);
-        foreach (var header in originalContent.Headers)
-            replacementContent.Headers.TryAddWithoutValidation(header.Key, header.Value);
-        response.Content = replacementContent;
+        var content = await originalContent.ReadAsStringAsync(cancellationToken);
+        response.Content = new StringContent(
+            content,
+            System.Text.Encoding.UTF8,
+            originalContent.Headers.ContentType?.MediaType ?? "application/json");
         originalContent.Dispose();
 
-        if (!IsPaidTierRequiredError(contentBytes))
+        if (!IsPaidTierRequiredError(content))
             return response;
 
         response.Dispose();
         throw new InvalidOperationException(PaidTierRequiredMessage);
     }
 
-    private bool ShouldInspect(HttpStatusCode statusCode)
-        => statusCode == HttpStatusCode.BadRequest
-            || statusCode == HttpStatusCode.TooManyRequests;
-
-    private bool IsPaidTierRequiredError(byte[] contentBytes)
+    private static bool IsPaidTierRequiredError(string content)
     {
         try
         {
-            var apiError = JsonSerializer.Deserialize<GoogleApiErrorEnvelope>(
-                contentBytes,
-                GoogleApiErrorJsonSerializerOptions);
-            return apiError?.Error is { Code: 400, Status: "FAILED_PRECONDITION" }
-                || apiError?.Error is { Code: 429, Status: "RESOURCE_EXHAUSTED" };
+            using var document = JsonDocument.Parse(content);
+            return document.RootElement.TryGetProperty("error", out var error)
+                && error.TryGetProperty("code", out var code)
+                && error.TryGetProperty("status", out var status)
+                && code.TryGetInt32(out var errorCode)
+                && status.ValueKind == JsonValueKind.String
+                && (errorCode, status.GetString()) is (400, "FAILED_PRECONDITION")
+                    or (429, "RESOURCE_EXHAUSTED");
         }
         catch (JsonException)
         {
             return false;
         }
     }
-}
-
-internal sealed class GoogleApiErrorEnvelope
-{
-    public GoogleApiError? Error { get; init; }
-}
-
-internal sealed class GoogleApiError
-{
-    public int Code { get; init; }
-
-    public string? Status { get; init; }
 }

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -13,14 +13,12 @@ namespace WondayWall.Services;
 
 public class GoogleAiService(AppConfigService configService, IHttpClientFactory httpClientFactory, ILogger<GoogleAiService> logger)
 {
-    internal const string GoogleAiHttpClientName = "GoogleAi";
     private const string GoogleAiApiKeyPageUrl = "https://aistudio.google.com/app/api-keys";
     private const string PaidTierRequiredMessage =
         "無料枠または課金未設定の Google AI API キーでは、この画像生成機能を利用できません。Google AI Studio で課金設定済みのプロジェクト/APIキーを確認してください: "
         + GoogleAiApiKeyPageUrl;
 
     private readonly HttpClient httpClient = httpClientFactory.CreateClient("WondayWall");
-    private readonly HttpClient googleAiHttpClient = httpClientFactory.CreateClient(GoogleAiHttpClientName);
     private static readonly string FixedImageSavePath = Path.Combine(
         System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData),
         "WondayWall", "wallpapers");
@@ -45,7 +43,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         var textModel = new GenerativeModelEx(
             config.GoogleAiApiKey,
             "gemini-3-flash-preview",
-            httpClient: googleAiHttpClient,
+            httpClient: httpClient,
             logger: logger)
         {
             UseGoogleSearch = true,
@@ -91,7 +89,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
             config.GoogleAiApiKey,
             "gemini-3.1-flash-image-preview",
             genConfig,
-            httpClient: googleAiHttpClient,
+            httpClient: httpClient,
             logger: logger)
         {
             UseGoogleSearch = true,

--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -13,12 +13,10 @@ namespace WondayWall.Services;
 
 public class GoogleAiService(AppConfigService configService, IHttpClientFactory httpClientFactory, ILogger<GoogleAiService> logger)
 {
-    internal const string PromptHttpClientName = "GoogleAiPrompt";
-    internal const string ImageHttpClientName = "GoogleAiImage";
+    internal const string GoogleAiHttpClientName = "GoogleAi";
 
     private readonly HttpClient httpClient = httpClientFactory.CreateClient("WondayWall");
-    private readonly HttpClient googleAiPromptHttpClient = httpClientFactory.CreateClient(PromptHttpClientName);
-    private readonly HttpClient googleAiImageHttpClient = httpClientFactory.CreateClient(ImageHttpClientName);
+    private readonly HttpClient googleAiHttpClient = httpClientFactory.CreateClient(GoogleAiHttpClientName);
     private static readonly string FixedImageSavePath = Path.Combine(
         System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData),
         "WondayWall", "wallpapers");
@@ -43,7 +41,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
         var textModel = new GenerativeModelEx(
             config.GoogleAiApiKey,
             "gemini-3-flash-preview",
-            httpClient: googleAiPromptHttpClient,
+            httpClient: googleAiHttpClient,
             logger: logger)
         {
             UseGoogleSearch = true,
@@ -80,7 +78,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
             config.GoogleAiApiKey,
             "gemini-3.1-flash-image-preview",
             genConfig,
-            httpClient: googleAiImageHttpClient,
+            httpClient: googleAiHttpClient,
             logger: logger)
         {
             UseGoogleSearch = true,
@@ -280,13 +278,7 @@ public class GoogleAiService(AppConfigService configService, IHttpClientFactory 
 
 }
 
-internal sealed class GoogleAiPromptErrorMessageHandler()
-    : GoogleAiErrorMessageHandler(treatResourceExhaustedAsPaidTierRequired: true);
-
-internal sealed class GoogleAiImageErrorMessageHandler()
-    : GoogleAiErrorMessageHandler(treatResourceExhaustedAsPaidTierRequired: false);
-
-internal abstract class GoogleAiErrorMessageHandler(bool treatResourceExhaustedAsPaidTierRequired) : DelegatingHandler
+internal sealed class GoogleAiErrorMessageHandler : DelegatingHandler
 {
     private const string GoogleAiApiKeyPageUrl = "https://aistudio.google.com/app/api-keys";
     private const string PaidTierRequiredMessage =
@@ -320,7 +312,7 @@ internal abstract class GoogleAiErrorMessageHandler(bool treatResourceExhaustedA
 
     private bool ShouldInspect(HttpStatusCode statusCode)
         => statusCode == HttpStatusCode.BadRequest
-            || (treatResourceExhaustedAsPaidTierRequired && statusCode == HttpStatusCode.TooManyRequests);
+            || statusCode == HttpStatusCode.TooManyRequests;
 
     private bool IsPaidTierRequiredError(byte[] contentBytes)
     {
@@ -330,8 +322,7 @@ internal abstract class GoogleAiErrorMessageHandler(bool treatResourceExhaustedA
                 contentBytes,
                 GoogleApiErrorJsonSerializerOptions);
             return apiError?.Error is { Code: 400, Status: "FAILED_PRECONDITION" }
-                || (treatResourceExhaustedAsPaidTierRequired
-                    && apiError?.Error is { Code: 429, Status: "RESOURCE_EXHAUSTED" });
+                || apiError?.Error is { Code: 429, Status: "RESOURCE_EXHAUSTED" };
         }
         catch (JsonException)
         {

--- a/WondayWall/Views/MainWindow.xaml
+++ b/WondayWall/Views/MainWindow.xaml
@@ -359,9 +359,14 @@
                                             <ui:CardControl.Icon>
                                                 <ui:SymbolIcon Symbol="Password24" />
                                             </ui:CardControl.Icon>
-                                            <ui:PasswordBox
-                                                Width="320"
-                                                Password="{Binding AppConfig.GoogleAiApiKey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                            <StackPanel>
+                                                <ui:PasswordBox
+                                                    Width="320"
+                                                    Password="{Binding AppConfig.GoogleAiApiKey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                                <TextBlock Margin="0,8,0,0">
+                                                    <Hyperlink NavigateUri="https://aistudio.google.com/app/api-keys" RequestNavigate="ApiKeyLink_RequestNavigate">APIキー取得ページを開く</Hyperlink>
+                                                </TextBlock>
+                                            </StackPanel>
                                         </ui:CardControl>
                                         <ui:CardControl Header="ユーザープロンプト（追加の指示）">
                                             <ui:CardControl.Icon>
@@ -489,6 +494,9 @@
                                         Width="420"
                                         Margin="0,8,0,0"
                                         Password="{Binding AppConfig.GoogleAiApiKey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                    <TextBlock Margin="0,8,0,0">
+                                        <Hyperlink NavigateUri="https://aistudio.google.com/app/api-keys" RequestNavigate="ApiKeyLink_RequestNavigate">APIキー取得ページを開く</Hyperlink>
+                                    </TextBlock>
                                 </StackPanel>
                             </ui:CardControl>
 

--- a/WondayWall/Views/MainWindow.xaml.cs
+++ b/WondayWall/Views/MainWindow.xaml.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using System.Windows.Input;
+using System.Windows.Navigation;
 using WondayWall.Models;
 using WondayWall.ViewModels;
 using Wpf.Ui.Appearance;
@@ -23,5 +25,15 @@ public partial class MainWindow : FluentWindow
             return;
 
         viewModel.OpenHistoryImageCommand.Execute(historyItem);
+    }
+
+    private void ApiKeyLink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+    {
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = e.Uri.AbsoluteUri,
+            UseShellExecute = true,
+        });
+        e.Handled = true;
     }
 }


### PR DESCRIPTION
## 概要
- Google AI APIキー入力欄に AI Studio の APIキー取得ページへのリンクを追加
- 初回セットアップの APIキー入力欄にも同じリンクを追加
- Gemini API の無料Tier/課金未設定系エラーを専用メッセージに変換

## 背景
Issue #61 の対応です。Google AI API へ渡す `HttpClient` は DI の named client から受け取り、SDK 呼び出し前後で個別に `new HttpClient(...)` しない形にしています。

## エラー判定
- `Google_GenerativeAI` 3.6.4 の GitHub ソースで、非成功レスポンスは `ApiBase.CheckAndHandleErrors` から `ApiException` として投げられ、`ErrorCode` / `ErrorStatus` が公開されていることを確認しました
- そのため `HttpMessageHandler` ではフックせず、Gemini 呼び出し側で `ApiException` を catch して `400 FAILED_PRECONDITION` と `429 RESOURCE_EXHAUSTED` を専用メッセージに変換します
- その他の `403 PERMISSION_DENIED` / `404 NOT_FOUND` / 判定不能なレスポンスは元のエラー扱いです

## 確認
- `dotnet restore WondayWall\WondayWall.csproj`
- `dotnet build WondayWall\WondayWall.csproj --no-restore`
- `git diff --check`
