### PR TITLE
[codex] 生成画像の拡張子をMIMEタイプから決定する

### DIFF
--- a/WondayWall/Services/GoogleAiService.cs
+++ b/WondayWall/Services/GoogleAiService.cs
@@ -154,13 +154,13 @@ public class GoogleAiService(
             throw new InvalidOperationException(PaidTierRequiredMessage, ex);
         }
 
-        var imageBytes = ExtractImageBytes(response);
+        var imageData = ExtractImageBytes(response);
 
-        if (imageBytes == null || imageBytes.Length == 0)
+        if (imageData == null || imageData.Value.Bytes.Length == 0)
             throw new InvalidOperationException("No image data returned from Google AI.");
 
-        var filePath = FileNameHelper.GetImageFilePath(FixedImageSavePath);
-        await File.WriteAllBytesAsync(filePath, imageBytes, ct).ConfigureAwait(false);
+        var filePath = FileNameHelper.GetImageFilePath(FixedImageSavePath, extension: imageData.Value.Extension);
+        await File.WriteAllBytesAsync(filePath, imageData.Value.Bytes, ct).ConfigureAwait(false);
 
         return new(filePath, DateTime.Now, imagePrompt, serviceTier, context);
     }
@@ -334,16 +334,20 @@ public class GoogleAiService(
         return string.Join("\n\n", parts);
     }
 
-    private static byte[]? ExtractImageBytes(GenerateContentResponse response)
+    private static (byte[] Bytes, string Extension)? ExtractImageBytes(GenerateContentResponse response)
     {
         foreach (var candidate in response.Candidates ?? [])
         {
             foreach (var part in candidate.Content?.Parts ?? [])
             {
-                if (part.InlineData?.MimeType?.StartsWith("image/") == true &&
+                if (part.InlineData?.MimeType?.StartsWith("image/", StringComparison.OrdinalIgnoreCase) == true &&
                     part.InlineData.Data != null)
                 {
-                    return Convert.FromBase64String(part.InlineData.Data);
+                    var extension = part.InlineData.MimeType["image/".Length..].Trim().ToLowerInvariant();
+                    if (extension.Length == 0)
+                        continue;
+
+                    return (Convert.FromBase64String(part.InlineData.Data), extension);
                 }
             }
         }


### PR DESCRIPTION
## 概要

- Gemini 画像生成レスポンスの `InlineData.MimeType` から保存拡張子を決定するように変更しました。
- `image/png`、`image/jpeg`、`image/webp` などの MIME subtype をそのまま `FileNameHelper.GetImageFilePath` に渡します。
- MIME type が画像でない、または subtype が空の場合は、従来どおり画像データなしとして扱います。

## 影響

- 生成画像が実フォーマットと異なる `.png` 固定で保存される可能性をなくします。
- `GeneratedImageInfo`、履歴 JSON、UI 表示、`FileNameHelper` の公開シグネチャは変更していません。

## 確認

- `git diff --check`
- `dotnet restore WondayWall\WondayWall.csproj`
- `dotnet build WondayWall\WondayWall.csproj --no-restore`