### PR TITLE
[codex] Pages用CNAMEを追加

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+ww.studiofreesia.com


### PR DESCRIPTION
## 概要
- GitHub Pages の `Deploy from a branch` / `main` / `/docs` 構成で custom domain を保持するため、`docs/CNAME` を追加しました。
- 内容は `ww.studiofreesia.com` の1行のみです。

## 背景
- GitHub Pages の branch publish では custom domain が publishing source root の `CNAME` ファイルで保持されます。
- API から custom domain を設定しようとすると GitHub が `docs/CNAME` を main に commit しようとしますが、main が protected のため失敗していました。

## 確認
- `git diff --cached --check`
- `main...codex/issue-75-pages-cname` の差分が `docs/CNAME` 1ファイルのみであることを確認