### PR TITLE
docs: dev.md を現在の実装に合わせて更新

### DIFF
--- a/dev.md
+++ b/dev.md
@@ -2,30 +2,28 @@
 
 ## 概要
 
-本書は、WPF ベースの壁紙生成アプリを **最小限の構成で実装するための指針** をまとめたものである。
-対象は初期実装であり、設計の美しさよりも **完成の速さ、修正のしやすさ、構成の分かりやすさ** を優先する。
+本書は、WPF ベースの壁紙生成アプリの実装指針をまとめたものである。
+設計の美しさよりも **完成の速さ、修正のしやすさ、構成の分かりやすさ** を優先する。
 
-本アプリは、ユーザーの予定や関心に応じて画像を生成し、壁紙として適用する。初期版では常駐アプリにはせず、**GUI モード** と **CLI モード** を 1 つの exe にまとめたハイブリッド構成を採用する。
+本アプリは、ユーザーの予定や関心に応じて画像を生成し、壁紙として適用する。常駐アプリにはせず、**GUI モード** と **CLI モード** を 1 つの exe にまとめたハイブリッド構成を採用する。
 
 ---
 
 ## 前提条件
 
 * UI: WPF
-* UI ライブラリ: **WPF-UI**
-* ホスト / DI: **Kamishibai**
-* コマンドライン: **ConsoleAppFramework**
-* フレームワーク: **.NET 10**
+* UI ライブラリ: **WPF-UI 4.2.0**
+* ホスト / DI: **Kamishibai 3.1.0**
+* コマンドライン: **ConsoleAppFramework 5.x**
+* フレームワーク: **.NET 10**（`net10.0-windows10.0.22621.0`）
 * プロジェクト数: **1**
-* 実装は別環境で行う
 * 本書は **実装指針のみ** を扱う
-* 初期仕様では **仮想デスクトップ対応を含めない**
 
 ---
 
 ## 採用方針
 
-初期版は **常駐しないハイブリッド型** とする。
+**常駐しないハイブリッド型** とする。
 
 ここでいうハイブリッド型とは、トレイ常駐型アプリではなく、**1 つの exe を GUI と CLI の両方で使い分ける構成** を指す。
 
@@ -39,7 +37,7 @@
   → `generate` で **同様の処理を即時実行する**
 
 つまり、**通常時は常駐しない**。
-一方で、同じ exe から GUI と CLI の両方を提供するため、この構成をハイブリッド型とする。
+同じ exe から GUI と CLI の両方を提供するため、この構成をハイブリッド型とする。
 
 ---
 
@@ -82,7 +80,7 @@
 ### 起動例
 
 ```powershell
-AppName.exe
+WondayWall.exe
 ```
 
 ## RunOnce モード
@@ -100,16 +98,14 @@ AppName.exe
 ### 起動例
 
 ```powershell
-AppName.exe run-once
+WondayWall.exe run-once
 ```
 
 または
 
 ```powershell
-AppName.exe generate
+WondayWall.exe generate
 ```
-
-コマンド名は `ConsoleAppFramework` に合わせて最終調整する。
 
 ---
 
@@ -170,7 +166,7 @@ AppName.exe generate
 ## 初期版の最小フォルダ構成
 
 ```text
-AppName/
+WondayWall/
   App.xaml
   App.xaml.cs
   Program.cs
@@ -184,33 +180,51 @@ AppName/
 
   Models/
     AppConfig.cs
+    AvailableCalendar.cs
     CalendarEventItem.cs
+    ContextBuildResult.cs
+    GeneratedImageInfo.cs
+    GoogleAiServiceTier.cs
+    HistoryItem.cs
     NewsTopicItem.cs
     PromptContext.cs
-    GeneratedImageInfo.cs
-    HistoryItem.cs
+    PromptTemplate.cs
+    UpdateInfo.cs
 
   Services/
     AppConfigService.cs
     ContextService.cs
-    GoogleAiService.cs
-    WallpaperService.cs
     GenerationCoordinator.cs
+    GoogleAiService.cs
+    HistoryService.cs
+    TaskSchedulerService.cs
+    UpdateChecker.cs
+    WallpaperService.cs
 
   Commands/
     CliCommands.cs
 
+  ComponentModel/
+    CredentialSecretAttribute.cs
+    CredentialSecretJsonConverter.cs
+    GenerativeModelEx.cs
+
   Utils/
-    JsonFileHelper.cs
+    AppLinks.cs
+    CredentialSecretStore.cs
+    DisplayHelper.cs
     FileNameHelper.cs
-    TimeHelper.cs
+    JsonFileHelper.cs
+    PathUtility.cs
+    ScheduleHelper.cs
+    UrlToFaviconConverter.cs
 ```
 
 ---
 
 ## クラス設計方針
 
-初期版では **interface をほぼ作らず、具体クラス中心で実装する**。
+**interface をほぼ作らず、具体クラス中心で実装する**。
 
 差し替え先が存在しない段階で抽象化を増やすと、構成が見えにくくなり、保守コストが上がりやすい。まずは責務のまとまりごとにクラスを切り、必要になった時点で分割や抽象化を行う。
 
@@ -234,16 +248,16 @@ AppName/
 
 * Google Calendar から予定を取得する
 * RSS / ニュースを取得する
-* `PromptContext` 用に整形する
+* `ContextBuildResult`（`PromptContext` + カレンダーイベント + ニューストピック）を返す
 
 #### 責務
 
 * Google OAuth / Calendar API 呼び出し
-* RSS 取得
+* RSS 取得と OGP メタデータ解析
 * 興味キーワードによる抽出
 * 予定 / ニュースの要約材料作成
 
-初期版では `CalendarService` と `NewsService` に分割しない。
+`CalendarService` と `NewsService` には分割しない。
 
 ### GoogleAiService
 
@@ -255,12 +269,11 @@ AppName/
 
 #### 責務
 
-* プロンプト生成
-* Google GenAI 呼び出し
-* エラー処理
-* 必要に応じた簡易リトライ
+* **2 ステップ生成**: まず Gemini Flash でテキストプロンプトを詳細化（Google Search グラウンディング有効）し、次に Gemini Flash Image で画像生成
+* Flex / Standard サービスティア切り替え（Flex 失敗時は Standard にフォールバック）
+* エラー処理・Polly リトライ
 
-初期版では `PromptBuilder` を分離しない。
+`PromptBuilder` は分離しない。
 
 ### WallpaperService
 
@@ -272,8 +285,8 @@ AppName/
 
 #### 責務
 
-* Win32 による壁紙変更
-* 適用画像の保持
+* `IDesktopWallpaper` / 仮想デスクトップ API による壁紙変更
+* ロック画面更新オプション（`UpdateLockScreen`）
 
 ### GenerationCoordinator
 
@@ -288,9 +301,47 @@ AppName/
 * 画像生成
 * 壁紙適用
 * 履歴追加
-* 同時実行防止
+* 同時実行防止（`SemaphoreSlim(1,1)`）
+* スキップ判定（`SkipGenerationWhenNoChanges` で変化なければスキップ）
 
 重要なのは、**GUI からも CLI からもこのクラスを呼ぶこと** である。処理本体を MainWindow 側に持たせない。
+
+エントリポイントは 2 つ。
+* `RunAsync()` — 手動生成（`generate` コマンド・GUI ボタン共用）
+* `RunScheduledAsync()` — スケジュール判定付き（`run-once` コマンド用）
+
+### HistoryService
+
+#### 役割
+
+* 生成履歴を保存・管理する
+
+#### 責務
+
+* `history.json` への追記（最大 100 件）
+* Singleton で保持し全体から参照
+
+### TaskSchedulerService
+
+#### 役割
+
+* Windows Task Scheduler に WondayWall タスクを登録・削除する
+
+#### 責務
+
+* `run-once` を指定スケジュールで実行するタスクの作成
+* タスクの有効化・無効化
+
+### UpdateChecker
+
+#### 役割
+
+* GitHub Releases API で新バージョンを確認する
+
+#### 責務
+
+* `BackgroundService` として GUI 起動時にバックグラウンドで実行
+* 新バージョンがあればトースト通知
 
 ### CliCommands
 
@@ -298,13 +349,15 @@ AppName/
 
 * `ConsoleAppFramework` のコマンド定義
 
-#### 候補コマンド
+#### コマンド一覧
 
-* `run-once`
-* `generate`
-* `check-calendar`
-* `check-news`
-* `check-google-ai`
+| コマンド | 説明 |
+|---------|------|
+| `run-once` | スケジュール枠が未処理なら実行（Task Scheduler 用） |
+| `generate` | 即時生成（手動実行用） |
+| `check-calendar` | Google Calendar 接続テスト・イベント一覧表示 |
+| `check-news` | RSS フィード取得・トピック表示 |
+| `check-google-ai` | Google AI API 接続テスト（サンプル画像生成） |
 
 CLI 側では、できるだけ `GenerationCoordinator` や `ContextService` を呼び出すだけにし、CLI 専用ロジックを増やさない。
 
@@ -312,22 +365,32 @@ CLI 側では、できるだけ `GenerationCoordinator` や `ContextService` を
 
 ## ViewModel 方針
 
-初期版は **MainWindowViewModel 1 個中心** で構成する。
+**MainWindowViewModel 1 個中心** で構成する。
 
 ### MainWindowViewModel が持つもの
 
 * 設定 (`AppConfig`)
-* 接続状態
-* 直近予定一覧
-* 直近ニュース一覧
-* 生成プレビュー情報
-* 最終生成画像
-* 履歴
-* 手動生成コマンド
-* 保存コマンド
-* 接続確認コマンド
+* カレンダー接続状態（`CalendarStatus`, `IsCalendarConnected`）
+* 直近予定一覧（`RecentEvents`）
+* 直近ニュース一覧（`RecentNews`）
+* 生成中フラグ（`IsGenerating`）
+* 最後に生成した画像情報（`LastGeneratedImage`, `LastImagePreviewPath`）
+* 前回実行結果メッセージ（`LastResultMessage`）
+* 生成履歴（`History`）
+* RSS ソース一覧（`RssSources`）
+* 利用可能なカレンダー一覧（`AvailableCalendars`）
+* プロンプトテンプレート（`SelectedPromptTemplate`）
+* Task Scheduler 有効フラグ（`IsTaskSchedulerEnabled`）
+* 更新情報（`HasUpdate`, `LatestVersion`, `IsCheckingUpdate`）
+* セットアップウィザード表示（`ShowSetupWizard`）
+* 手動生成コマンド（`GenerateCommand`）
+* カレンダー確認コマンド（`CheckCalendarCommand`）
+* ニュース確認コマンド（`CheckNewsCommand`）
+* スケジューラ有効化 / 無効化コマンド
+* RSS ソース追加 / 削除コマンド
+* 更新インストール・リリースノート表示・更新チェックコマンド
 
-初期版では次の分割は行わない。
+次の分割は行わない。
 
 * `SettingsViewModel`
 * `CalendarViewModel`
@@ -338,30 +401,51 @@ CLI 側では、できるだけ `GenerationCoordinator` や `ContextService` を
 
 ## 画面構成
 
-初期版は **1 ウィンドウ + 3 タブ** で十分とする。
+**1 ウィンドウ + 複数タブ** 構成。ベースは `<ui:FluentWindow>`（Mica バックドロップ）。
 
-### ホーム
+### タイトルバー
 
-* 現在の壁紙プレビュー
-* 手動生成ボタン
-* 次回定期実行の説明
-* 直近実行結果
+* 更新チェックボタン
+* 新バージョン通知バナー
 
-### データ
+### セットアップウィザード（初回のみ）
+
+* API キー入力
+* Google Calendar 接続
+
+### タブ：設定
+
+* Google AI API キー設定
+* 1 日あたりの実行回数（Task Scheduler 連動）
+* Task Scheduler 有効化 / 無効化ボタン
+
+### タブ：カレンダー連携
 
 * Google Calendar 接続状態
-* 取得対象カレンダー
-* 興味キーワード
-* RSS 一覧
-* 取得結果プレビュー
+* 取得対象カレンダー選択（`AvailableCalendars` チェックリスト）
+* 直近イベントプレビュー
+* 接続確認ボタン
 
-### 設定
+### タブ：RSS 設定
 
-* Google AI API 設定
-* 更新間隔
-* 保存先
-* Task Scheduler 用の説明
-* ログ出力設定
+* RSS ソース追加 / 削除
+* 取得トピックプレビュー
+* ニュース確認ボタン
+
+### タブ：プロンプトテンプレート
+
+* テンプレート選択
+* プロンプト内容表示・編集
+
+### タブ：履歴
+
+* 生成履歴一覧（ダブルクリックで画像表示）
+
+### 固定フッター / ホームエリア
+
+* 最後に生成した壁紙プレビュー
+* 手動生成ボタン（`IsGenerating` で制御）
+* 前回実行結果メッセージ
 
 ---
 
@@ -371,22 +455,28 @@ CLI 側では、できるだけ `GenerationCoordinator` や `ContextService` を
 
 ### 役割
 
-* 多重起動制御（必要であれば GUI のみ）
 * Host / DI 初期化
 * `ConsoleAppFramework` 起動
-* GUI モード時のみ WPF を起動
+* GUI モード時のみ WPF（Kamishibai）を起動
 * CLI モード時は処理を実行して終了
 
-### 登録するもの
+### 共通で登録するもの（Singleton）
 
 * `AppConfigService`
 * `ContextService`
 * `GoogleAiService`
 * `WallpaperService`
+* `HistoryService`
 * `GenerationCoordinator`
-* `CliCommands`
-* `MainWindow`
-* `MainWindowViewModel`
+* `TaskSchedulerService`
+* HttpClient（`"WondayWall"` 30 秒、`"Gemini"` 30 分 + Polly リトライ）
+
+### GUI 専用で登録するもの
+
+* `UpdateChecker`（`IHostedService` として登録）
+* `IGitHubClient`（Octokit）
+* HttpClient（`"WondayWallUpdate"` 10 分）
+* `MainWindow` / `MainWindowViewModel`（`AddPresentation<MainWindow, MainWindowViewModel>`）
 
 ### 登録しなくてよいもの
 
@@ -430,13 +520,14 @@ MainWindow は薄く保つ。
 
 ### AppConfig
 
-* Google AI API Key または設定
-* Google Calendar 設定
-* 興味キーワード
+* Google AI API キー（`[CredentialSecret]` 属性 → `PasswordVault` で暗号化保管）
+* Google Calendar カレンダー ID 一覧
 * RSS ソース一覧
-* 更新間隔
-* 保存先
-* ログ設定
+* ユーザー追加プロンプト
+* 1 日あたりの実行回数（`RunsPerDay`）
+* ベース壁紙を使うかどうか（`UseCurrentWallpaperAsBase`）
+* 変化なしのときスキップ（`SkipGenerationWhenNoChanges`）
+* ロック画面も更新（`UpdateLockScreen`）
 
 ### CalendarEventItem
 
@@ -445,27 +536,40 @@ MainWindow は薄く保つ。
 * 場所
 * 概要
 
+（UI 表示用。プロンプト向けには `PromptCalendarEvent` を使う）
+
 ### NewsTopicItem
 
 * タイトル
 * 要約
 * URL
-* 取得日時
-* 一致キーワード
+* 公開日時
+* OGP 画像 URL
+
+（UI 表示用。プロンプト向けには `PromptNewsTopic` を使う）
 
 ### PromptContext
 
-* 予定要約
-* ニュース要約
-* 雰囲気キーワード
-* 画像サイズ
+* カレンダーイベント（`PromptCalendarEvent` のリスト）
+* ニューストピック（`PromptNewsTopic` のリスト）
+* 画像サイズ・アスペクト比
+* ベース画像パス
 * 追加制約
+
+### ContextBuildResult
+
+* `PromptContext`
+* `CalendarEventItem` リスト（UI 表示用）
+* `NewsTopicItem` リスト（UI 表示用）
+
+`ContextService.BuildContextAsync()` の戻り値。
 
 ### GeneratedImageInfo
 
 * ファイルパス
 * 生成日時
 * 使用プロンプト
+* サービスティア（`GoogleAiServiceTier`）
 * 元コンテキスト
 
 ### HistoryItem
@@ -474,6 +578,35 @@ MainWindow は薄く保つ。
 * 成功 / 失敗
 * エラー概要
 * 適用画像パス
+* 使用したカレンダーイベント
+* 使用したニューストピック
+* サービスティア
+* スキップ済みフラグ（`IsSkipped`）
+
+### AvailableCalendar
+
+* カレンダー ID
+* 表示名
+* プライマリカレンダーかどうか
+* 選択状態（UI チェックボックス用）
+
+### GoogleAiServiceTier
+
+* `Standard`
+* `Flex`（失敗時 Standard にフォールバック）
+
+### PromptTemplate
+
+* テンプレート名
+* テンプレート本文
+
+### UpdateInfo
+
+* バージョン
+* リリース URL
+* ダウンロードパス
+* 確認日時
+* スキップフラグ
 
 ---
 
@@ -481,21 +614,19 @@ MainWindow は薄く保つ。
 
 ### GUI から手動生成する場合
 
-1. `MainWindowViewModel` から `GenerationCoordinator` を呼ぶ
-2. `ContextService` で予定 / ニュースを取得する
-3. `GoogleAiService` で画像を生成する
-4. `WallpaperService` で適用する
-5. 履歴を更新する
-6. 画面を更新する
+1. `MainWindowViewModel` から `GenerationCoordinator.RunAsync()` を呼ぶ
+2. `ContextService.BuildContextAsync()` で予定 / ニュースを取得し `ContextBuildResult` を返す
+3. `GoogleAiService.GenerateWallpaperAsync()` で画像生成（テキストプロンプト詳細化 → 画像生成の 2 ステップ）
+4. `WallpaperService` で壁紙を適用する
+5. `HistoryService` に結果を追記する
+6. ViewModel の ObservableCollection を更新して画面を更新する
 
 ### CLI の `run-once` を実行する場合
 
-1. `CliCommands` から `GenerationCoordinator` を呼ぶ
-2. `ContextService` で予定 / ニュースを取得する
-3. `GoogleAiService` で画像を生成する
-4. `WallpaperService` で適用する
-5. 履歴を更新する
-6. 終了コードを返して終了する
+1. `CliCommands` から `GenerationCoordinator.RunScheduledAsync()` を呼ぶ
+2. スケジュール枠が未処理かを確認し、スキップ条件を評価する
+3. （生成対象の場合）上記 2〜5 と同様の処理を実行する
+4. 終了コードを返して終了する
 
 **処理本体は共通化する。**
 
@@ -503,100 +634,112 @@ MainWindow は薄く保つ。
 
 ## 定期実行の考え方
 
-定期実行はアプリ内常駐ではなく、**Windows Task Scheduler** を使う前提とする。
+定期実行は **Windows Task Scheduler** を使う前提とする。GUI 上の「スケジューラ有効化」ボタンから `TaskSchedulerService` 経由でタスクの登録・削除が可能。
 
 ### 方式の例
 
 * ログオン時実行
-* 1 時間ごとの実行
-* 朝 / 昼 / 夜だけ実行
+* 1 日 1〜24 回（`SupportedRunsPerDay` = [1, 2, 3, 4, 6, 8, 12, 24]）
 
-これらはタスクスケジューラ側で設定する。
+スロット時刻の計算は `ScheduleHelper` が担う。
 
 ### アプリ側でやること
 
-* `run-once` コマンドを用意する
-* `0` を成功、`1` を失敗などの終了コードとして返す
-* ログを残す
+* `run-once` コマンドを用意する（`0` を成功、`1` を失敗として返す）
+* `TaskSchedulerService` でタスクを登録・削除する
+* `run-once` 呼び出し時に `SkipGenerationWhenNoChanges` でスキップ判定する
 
 ### アプリ側でやらないこと
 
 * 常駐タイマー
 * トレイからの定期実行管理
 
-初期版ではここまでで十分である。
-
 ---
 
-## ライブラリ方針
+## ライブラリ
 
-### 採用するもの
+### 採用しているもの
 
-* `CommunityToolkit.Mvvm`
-* `WPF-UI`
-* `Kamishibai.Hosting`
-* `ConsoleAppFramework`
-* `Google.GenAI`
-* `Google.Apis.Calendar.v3`
-* `Microsoft.Extensions.Hosting`
-* `Microsoft.Extensions.DependencyInjection`
-* `System.ServiceModel.Syndication`
-* 必要に応じて `SixLabors.ImageSharp`
+| パッケージ | バージョン | 用途 |
+|-----------|----------|------|
+| `CommunityToolkit.Mvvm` | 8.4.2 | MVVM / `[ObservableProperty]` / `[RelayCommand]` |
+| `WPF-UI` | 4.2.0 | Fluent WPF コンポーネント |
+| `Kamishibai` / `Kamishibai.Hosting` | 3.1.0 | WPF + Generic Host 統合・DI |
+| `ConsoleAppFramework` | 5.x | CLI コマンドルーティング |
+| `Google_GenerativeAI` | 3.6.4 | Gemini API（テキスト＋画像生成） |
+| `Google.Apis.Calendar.v3` | 1.73.x | Google Calendar API |
+| `Microsoft.Extensions.Hosting` | 10.x | ホスティング・BackgroundService |
+| `Microsoft.Extensions.Http` | 10.x | `IHttpClientFactory` |
+| `Microsoft.Extensions.Http.Resilience` | 10.x | Polly リトライ |
+| `System.ServiceModel.Syndication` | 10.x | RSS フィード解析 |
+| `OpenGraph-Net` | 4.0.1 | OGP メタデータ解析 |
+| `Octokit` | 14.x | GitHub Releases API（更新チェック用） |
+| `Microsoft.Toolkit.Uwp.Notifications` | 7.1.3 | トースト通知 |
+| `Slions.VirtualDesktop.WPF` | 6.9.2 | 仮想デスクトップ別壁紙 |
+| `TaskScheduler` | 2.x | Windows Task Scheduler 操作 |
+| `Microsoft.Windows.CsWin32` | 0.3.x | Win32 API ラッパー生成 |
+| `Nito.AsyncEx.Coordination` | 5.1.2 | `AsyncLock` |
 
-### 初期版では入れないもの
+### 採用していないもの
 
 * MediatR
 * ReactiveUI
 * AutoMapper
-* Polly
 * Repository パターン一式
 * 大規模ログ基盤
 * interface の大量定義
 
 ---
 
-## 実装順序
+## 実装ステップ（完了済み）
 
-### Step 1
+### Step 1 ✅
 
 * WPF-UI で MainWindow を作る
 * Kamishibai で起動する
 * 設定保存 / 読み込みを作る
 
-### Step 2
+### Step 2 ✅
 
 * `WallpaperService` を作る
 * 手動で画像を選んで壁紙適用できるようにする
 
-### Step 3
+### Step 3 ✅
 
 * `ConsoleAppFramework` を導入する
 * `run-once` コマンドを先に作る
 * GUI と CLI の共存を成立させる
 
-### Step 4
+### Step 4 ✅
 
 * Google AI 接続
 * 固定プロンプトで画像生成
 * 保存まで実装
 
-### Step 5
+### Step 5 ✅
 
 * Google Calendar 接続
 * 予定取得
 * 画面表示
 
-### Step 6
+### Step 6 ✅
 
 * RSS 取得
-* 興味キーワード抽出
+* OGP メタデータ解析
 * 画面表示
 
-### Step 7
+### Step 7 ✅
 
 * `GenerationCoordinator` で全体を接続する
 * `run-once` を完成させる
-* Task Scheduler 前提の運用にする
+* Task Scheduler 連動（`TaskSchedulerService`）
+
+### Step 8 ✅
+
+* Gemini 2 ステップ生成（テキストプロンプト詳細化 → 画像生成）
+* Flex / Standard サービスティア対応
+* 仮想デスクトップ別壁紙対応
+* `UpdateChecker`（GitHub Releases 自動チェック・トースト通知）
 
 ---
 
@@ -605,26 +748,20 @@ MainWindow は薄く保つ。
 必要になった段階で追加する。
 
 * タスクトレイ常駐
-* 仮想デスクトップ別の壁紙
-* 複数モニタ対応
+* 複数モニタ個別壁紙
 * `PromptBuilder` の分離
-* `ContextService` の分割
+* `ContextService` の分割（`CalendarService` / `NewsService`）
 * interface 導入
-
-初期版では行わない。
 
 ---
 
-## 最終方針
-
-初期版は次の方針で十分である。
+## 方針まとめ
 
 * **常駐しない**
 * **同じ exe で GUI と CLI を両立する**
 * **WPF-UI + Kamishibai + ConsoleAppFramework を採用する**
-* **ViewModel は 1 個中心で構成する**
-* **サービスは 5 個程度に抑える**
-* **interface は基本的に作らない**
-* **Task Scheduler 前提で定期実行する**
-
-この構成であれば、設計過多を避けつつ、後から拡張しやすい。
+* **ViewModel は `MainWindowViewModel` 1 個**
+* **サービスは具体クラス直接参照（interface なし）**
+* **Task Scheduler 連動で定期実行する（`TaskSchedulerService` でアプリ内登録）**
+* **API キーは `PasswordVault` で暗号化保管**
+* **Gemini は 2 ステップ生成（テキストプロンプト詳細化 → 画像生成）**

--- a/dev.md
+++ b/dev.md
@@ -1,4 +1,4 @@
-# WPF 壁紙生成アプリ 実装指針
+﻿# WPF 壁紙生成アプリ 実装指針
 
 ## 概要
 
@@ -9,759 +9,97 @@
 
 ---
 
-## 前提条件
+## アーキテクチャ方針
 
-* UI: WPF
-* UI ライブラリ: **WPF-UI 4.2.0**
-* ホスト / DI: **Kamishibai 3.1.0**
-* コマンドライン: **ConsoleAppFramework 5.x**
+**常駐しないハイブリッド型**とする。トレイ常駐ではなく、1 つの exe を GUI と CLI の両方で使い分ける。
+
+| モード | 起動方法 | 用途 |
+|--------|---------|------|
+| GUI モード | 引数なし起動 | 設定・接続確認・手動生成・履歴確認 |
+| `run-once` | Task Scheduler から呼び出す | スケジュール枠の未処理確認 → 生成 → 終了 |
+| `generate` | 手動 CLI 実行 | 即時生成 → 終了 |
+| `check-*` | 手動 CLI 実行 | Calendar / News / AI の接続確認 |
+
+**「設定は GUI」「定期処理は CLI」** の役割分担で常駐を避ける。
+
+---
+
+## 技術スタック
+
+* UI: **WPF + WPF-UI**（`<ui:FluentWindow>` ベース、Mica バックドロップ）
+* ホスト / DI: **Kamishibai**（WPF + Generic Host 統合）
+* CLI: **ConsoleAppFramework**
 * フレームワーク: **.NET 10**（`net10.0-windows10.0.22621.0`）
-* プロジェクト数: **1**
-* 本書は **実装指針のみ** を扱う
 
 ---
 
-## 採用方針
+## サービス構成
 
-**常駐しないハイブリッド型** とする。
+サービスはすべて **Singleton**。**interface を設けず具体クラス直接参照**。
 
-ここでいうハイブリッド型とは、トレイ常駐型アプリではなく、**1 つの exe を GUI と CLI の両方で使い分ける構成** を指す。
-
-### 動作イメージ
-
-* ユーザーが通常起動した場合
-  → **WPF の設定 UI を開く**
-* Task Scheduler などから定期実行された場合
-  → `run-once` で **UI を表示せずに 1 回だけ処理を行って終了する**
-* 手動実行用コマンドを使う場合
-  → `generate` で **同様の処理を即時実行する**
-
-つまり、**通常時は常駐しない**。
-同じ exe から GUI と CLI の両方を提供するため、この構成をハイブリッド型とする。
-
----
-
-## この構成を採用する理由
-
-本アプリで必要となる基本処理は次の 4 つである。
-
-1. カレンダーやニュースを取得する
-2. Google AI で画像を生成する
-3. 画像を壁紙として適用する
-4. 処理を終了する
-
-この処理において、初期段階では常駐は必須ではない。むしろ常駐型にすると、次のような複雑さが追加される。
-
-* タスクトレイの実装
-* 多重起動制御
-* 起動中状態の同期
-* 常駐中の再認証導線
-* メモリ常駐の管理
-* UI とバックグラウンド処理の寿命管理
-
-初期版ではこれらを避け、**「設定は GUI」「定期処理は CLI」** という役割分担にすることで、構成を単純に保つ。
-
----
-
-## 実行モード
-
-## GUI モード
-
-通常起動時のモードであり、主に設定と確認に使用する。
-
-### 用途
-
-* 設定編集
-* 接続確認
-* 予定 / ニュースのプレビュー
-* 手動生成
-* 履歴確認
-
-### 起動例
-
-```powershell
-WondayWall.exe
-```
-
-## RunOnce モード
-
-定期実行用のモードであり、処理を 1 回だけ実行して終了する。
-
-### 用途
-
-* データ取得
-* 画像生成
-* 壁紙適用
-* ログ保存
-* 終了
-
-### 起動例
-
-```powershell
-WondayWall.exe run-once
-```
-
-または
-
-```powershell
-WondayWall.exe generate
-```
-
----
-
-## 技術構成
-
-## UI
-
-* **WPF**
-* **WPF-UI**
-
-### 役割
-
-* MainWindow の見た目
-* タブ UI
-* ダイアログ
-* 画像プレビュー
-* 設定編集
-
-## Host / DI
-
-* **Kamishibai**
-
-### 役割
-
-* WPF と Generic Host の統合
-* Service 登録
-* View / ViewModel の解決
-* 起動フローの整理
-
-## CLI
-
-* **ConsoleAppFramework**
-
-### 役割
-
-* `run-once`
-* `generate`
-* `check-calendar`
-* `check-news`
-* `check-google-ai`
-
-のようなコマンドを 1 つの exe に載せる。
-
----
-
-## 全体構成
-
-### 起動フロー
-
-1. `Program.cs` で起動する
-2. `ConsoleAppFramework` で引数を判定する
-3. GUI モードなら Kamishibai 経由で WPF を起動する
-4. CLI モードなら Host から必要なサービスを解決する
-5. 処理完了後に終了する
-
----
-
-## 初期版の最小フォルダ構成
-
-```text
-WondayWall/
-  App.xaml
-  App.xaml.cs
-  Program.cs
-
-  Views/
-    MainWindow.xaml
-    MainWindow.xaml.cs
-
-  ViewModels/
-    MainWindowViewModel.cs
-
-  Models/
-    AppConfig.cs
-    AvailableCalendar.cs
-    CalendarEventItem.cs
-    ContextBuildResult.cs
-    GeneratedImageInfo.cs
-    GoogleAiServiceTier.cs
-    HistoryItem.cs
-    NewsTopicItem.cs
-    PromptContext.cs
-    PromptTemplate.cs
-    UpdateInfo.cs
-
-  Services/
-    AppConfigService.cs
-    ContextService.cs
-    GenerationCoordinator.cs
-    GoogleAiService.cs
-    HistoryService.cs
-    TaskSchedulerService.cs
-    UpdateChecker.cs
-    WallpaperService.cs
-
-  Commands/
-    CliCommands.cs
-
-  ComponentModel/
-    CredentialSecretAttribute.cs
-    CredentialSecretJsonConverter.cs
-    GenerativeModelEx.cs
-
-  Utils/
-    AppLinks.cs
-    CredentialSecretStore.cs
-    DisplayHelper.cs
-    FileNameHelper.cs
-    JsonFileHelper.cs
-    PathUtility.cs
-    ScheduleHelper.cs
-    UrlToFaviconConverter.cs
-```
-
----
-
-## クラス設計方針
-
-**interface をほぼ作らず、具体クラス中心で実装する**。
-
-差し替え先が存在しない段階で抽象化を増やすと、構成が見えにくくなり、保守コストが上がりやすい。まずは責務のまとまりごとにクラスを切り、必要になった時点で分割や抽象化を行う。
-
-### AppConfigService
-
-#### 役割
-
-* 設定の読み込み
-* 設定の保存
-* 保存先ディレクトリの決定
-* デフォルト設定の生成
-
-#### 責務
-
-* JSON 入出力
-* 設定ファイルパスの管理
-
-### ContextService
-
-#### 役割
-
-* Google Calendar から予定を取得する
-* RSS / ニュースを取得する
-* `ContextBuildResult`（`PromptContext` + カレンダーイベント + ニューストピック）を返す
-
-#### 責務
-
-* Google OAuth / Calendar API 呼び出し
-* RSS 取得と OGP メタデータ解析
-* 興味キーワードによる抽出
-* 予定 / ニュースの要約材料作成
-
-`CalendarService` と `NewsService` には分割しない。
-
-### GoogleAiService
-
-#### 役割
-
-* `PromptContext` からプロンプトを組み立てる
-* Google AI に画像生成を依頼する
-* 結果画像を保存する
-
-#### 責務
-
-* **2 ステップ生成**: まず Gemini Flash でテキストプロンプトを詳細化（Google Search グラウンディング有効）し、次に Gemini Flash Image で画像生成
-* Flex / Standard サービスティア切り替え（Flex 失敗時は Standard にフォールバック）
-* エラー処理・Polly リトライ
-
-`PromptBuilder` は分離しない。
-
-### WallpaperService
-
-#### 役割
-
-* 壁紙を反映する
-* 画像パスを検証する
-* 最終適用画像を管理する
-
-#### 責務
-
-* `IDesktopWallpaper` / 仮想デスクトップ API による壁紙変更
-* ロック画面更新オプション（`UpdateLockScreen`）
-
-### GenerationCoordinator
-
-#### 役割
-
-* 全体フローの司令塔
-* GUI の手動生成と CLI の `run-once` を共通化する
-
-#### 責務
-
-* コンテキスト取得
-* 画像生成
-* 壁紙適用
-* 履歴追加
-* 同時実行防止（`SemaphoreSlim(1,1)`）
-* スキップ判定（`SkipGenerationWhenNoChanges` で変化なければスキップ）
-
-重要なのは、**GUI からも CLI からもこのクラスを呼ぶこと** である。処理本体を MainWindow 側に持たせない。
-
-エントリポイントは 2 つ。
-* `RunAsync()` — 手動生成（`generate` コマンド・GUI ボタン共用）
-* `RunScheduledAsync()` — スケジュール判定付き（`run-once` コマンド用）
-
-### HistoryService
-
-#### 役割
-
-* 生成履歴を保存・管理する
-
-#### 責務
-
-* `history.json` への追記（最大 100 件）
-* Singleton で保持し全体から参照
-
-### TaskSchedulerService
-
-#### 役割
-
-* Windows Task Scheduler に WondayWall タスクを登録・削除する
-
-#### 責務
-
-* `run-once` を指定スケジュールで実行するタスクの作成
-* タスクの有効化・無効化
-
-### UpdateChecker
-
-#### 役割
-
-* GitHub Releases API で新バージョンを確認する
-
-#### 責務
-
-* `BackgroundService` として GUI 起動時にバックグラウンドで実行
-* 新バージョンがあればトースト通知
-
-### CliCommands
-
-#### 役割
-
-* `ConsoleAppFramework` のコマンド定義
-
-#### コマンド一覧
-
-| コマンド | 説明 |
+| サービス | 責務 |
 |---------|------|
-| `run-once` | スケジュール枠が未処理なら実行（Task Scheduler 用） |
-| `generate` | 即時生成（手動実行用） |
-| `check-calendar` | Google Calendar 接続テスト・イベント一覧表示 |
-| `check-news` | RSS フィード取得・トピック表示 |
-| `check-google-ai` | Google AI API 接続テスト（サンプル画像生成） |
-
-CLI 側では、できるだけ `GenerationCoordinator` や `ContextService` を呼び出すだけにし、CLI 専用ロジックを増やさない。
-
----
-
-## ViewModel 方針
-
-**MainWindowViewModel 1 個中心** で構成する。
-
-### MainWindowViewModel が持つもの
-
-* 設定 (`AppConfig`)
-* カレンダー接続状態（`CalendarStatus`, `IsCalendarConnected`）
-* 直近予定一覧（`RecentEvents`）
-* 直近ニュース一覧（`RecentNews`）
-* 生成中フラグ（`IsGenerating`）
-* 最後に生成した画像情報（`LastGeneratedImage`, `LastImagePreviewPath`）
-* 前回実行結果メッセージ（`LastResultMessage`）
-* 生成履歴（`History`）
-* RSS ソース一覧（`RssSources`）
-* 利用可能なカレンダー一覧（`AvailableCalendars`）
-* プロンプトテンプレート（`SelectedPromptTemplate`）
-* Task Scheduler 有効フラグ（`IsTaskSchedulerEnabled`）
-* 更新情報（`HasUpdate`, `LatestVersion`, `IsCheckingUpdate`）
-* セットアップウィザード表示（`ShowSetupWizard`）
-* 手動生成コマンド（`GenerateCommand`）
-* カレンダー確認コマンド（`CheckCalendarCommand`）
-* ニュース確認コマンド（`CheckNewsCommand`）
-* スケジューラ有効化 / 無効化コマンド
-* RSS ソース追加 / 削除コマンド
-* 更新インストール・リリースノート表示・更新チェックコマンド
-
-次の分割は行わない。
-
-* `SettingsViewModel`
-* `CalendarViewModel`
-* `NewsViewModel`
-* `HistoryViewModel`
+| `AppConfigService` | JSON 設定の読み書き（`%LocalAppData%/StudioFreesia/WondayWall/config.json`） |
+| `ContextService` | Google Calendar + RSS フィードから `ContextBuildResult` を構築 |
+| `GoogleAiService` | Gemini で壁紙画像を生成・保存（2 ステップ生成） |
+| `WallpaperService` | 仮想デスクトップ API / Win32 で壁紙を適用 |
+| `GenerationCoordinator` | 上記サービスを順次呼び出すオーケストレーター |
+| `HistoryService` | 生成履歴を `history.json` に保存（最大 100 件） |
+| `TaskSchedulerService` | Windows Task Scheduler へのタスク登録・削除 |
+| `UpdateChecker` | GitHub Releases API で新バージョン確認（BackgroundService） |
 
 ---
 
-## 画面構成
+## 生成フロー
 
-**1 ウィンドウ + 複数タブ** 構成。ベースは `<ui:FluentWindow>`（Mica バックドロップ）。
+`GenerationCoordinator` が GUI・CLI 両方から呼ばれる。処理本体はここに集約する。
 
-### タイトルバー
+```
+GenerationCoordinator（SemaphoreSlim で多重実行防止）
+  ├─ ContextService.BuildContextAsync()
+  │   ├─ Google Calendar API → カレンダーイベント
+  │   └─ RSS フィード + OGP 解析 → ニューストピック
+  ├─ GoogleAiService.GenerateWallpaperAsync()（2 ステップ生成）
+  │   ├─ Step 1: Gemini Flash でテキストプロンプト詳細化（Google Search グラウンディング）
+  │   └─ Step 2: Gemini Flash Image で画像生成
+  │       └─ Flex ティア失敗時は Standard にフォールバック
+  ├─ WallpaperService.SetWallpaperAsync()
+  └─ HistoryService.Append()
+```
 
-* 更新チェックボタン
-* 新バージョン通知バナー
-
-### セットアップウィザード（初回のみ）
-
-* API キー入力
-* Google Calendar 接続
-
-### タブ：設定
-
-* Google AI API キー設定
-* 1 日あたりの実行回数（Task Scheduler 連動）
-* Task Scheduler 有効化 / 無効化ボタン
-
-### タブ：カレンダー連携
-
-* Google Calendar 接続状態
-* 取得対象カレンダー選択（`AvailableCalendars` チェックリスト）
-* 直近イベントプレビュー
-* 接続確認ボタン
-
-### タブ：RSS 設定
-
-* RSS ソース追加 / 削除
-* 取得トピックプレビュー
-* ニュース確認ボタン
-
-### タブ：プロンプトテンプレート
-
-* テンプレート選択
-* プロンプト内容表示・編集
-
-### タブ：履歴
-
-* 生成履歴一覧（ダブルクリックで画像表示）
-
-### 固定フッター / ホームエリア
-
-* 最後に生成した壁紙プレビュー
-* 手動生成ボタン（`IsGenerating` で制御）
-* 前回実行結果メッセージ
+`run-once` 専用の `RunScheduledAsync()` はスキップ判定（`SkipGenerationWhenNoChanges`）を行ってから上記を呼ぶ。
 
 ---
 
-## Program.cs の方針
+## MVVM 方針
 
-`Program.cs` で実行モードを分岐する。
-
-### 役割
-
-* Host / DI 初期化
-* `ConsoleAppFramework` 起動
-* GUI モード時のみ WPF（Kamishibai）を起動
-* CLI モード時は処理を実行して終了
-
-### 共通で登録するもの（Singleton）
-
-* `AppConfigService`
-* `ContextService`
-* `GoogleAiService`
-* `WallpaperService`
-* `HistoryService`
-* `GenerationCoordinator`
-* `TaskSchedulerService`
-* HttpClient（`"WondayWall"` 30 秒、`"Gemini"` 30 分 + Polly リトライ）
-
-### GUI 専用で登録するもの
-
-* `UpdateChecker`（`IHostedService` として登録）
-* `IGitHubClient`（Octokit）
-* HttpClient（`"WondayWallUpdate"` 10 分）
-* `MainWindow` / `MainWindowViewModel`（`AddPresentation<MainWindow, MainWindowViewModel>`）
-
-### 登録しなくてよいもの
-
-* 細かい interface
-* 過剰な PresentationService
-* 分割しすぎた Options クラス
+* CommunityToolkit.MVVM の `[ObservableProperty]`・`[RelayCommand]` を使う
+* ViewModel は **`MainWindowViewModel` 1 個**。分割しない
+* MainWindow は薄く保つ（API 呼び出し・壁紙変更・スケジューリングを置かない）
 
 ---
 
-## App.xaml の方針
+## 定期実行
 
-役割は最小限にとどめる。
+定期実行は **Windows Task Scheduler** に委ねる。GUI の「スケジューラ有効化」ボタンから `TaskSchedulerService` 経由でタスクを登録・削除する。
 
-* WPF-UI のテーマ辞書
-* 共通スタイル
-* 必要であれば例外フック
-
-主要な起動ロジックは `Program.cs` に寄せる。
+* 1 日あたりの実行回数（1 / 2 / 3 / 4 / 6 / 8 / 12 / 24 回）を UI で設定
+* スロット時刻の計算は `ScheduleHelper` が担う
+* 常駐タイマーやトレイからの定期実行管理は行わない
 
 ---
 
-## MainWindow の方針
+## セキュリティ
 
-MainWindow は薄く保つ。
-
-### 役割
-
-* レイアウト
-* バインディング
-* ダイアログの起点
-
-### 置かないもの
-
-* API 呼び出し本体
-* 壁紙変更本体
-* スケジューリング本体
-
----
-
-## モデル
-
-### AppConfig
-
-* Google AI API キー（`[CredentialSecret]` 属性 → `PasswordVault` で暗号化保管）
-* Google Calendar カレンダー ID 一覧
-* RSS ソース一覧
-* ユーザー追加プロンプト
-* 1 日あたりの実行回数（`RunsPerDay`）
-* ベース壁紙を使うかどうか（`UseCurrentWallpaperAsBase`）
-* 変化なしのときスキップ（`SkipGenerationWhenNoChanges`）
-* ロック画面も更新（`UpdateLockScreen`）
-
-### CalendarEventItem
-
-* タイトル
-* 開始 / 終了時刻
-* 場所
-* 概要
-
-（UI 表示用。プロンプト向けには `PromptCalendarEvent` を使う）
-
-### NewsTopicItem
-
-* タイトル
-* 要約
-* URL
-* 公開日時
-* OGP 画像 URL
-
-（UI 表示用。プロンプト向けには `PromptNewsTopic` を使う）
-
-### PromptContext
-
-* カレンダーイベント（`PromptCalendarEvent` のリスト）
-* ニューストピック（`PromptNewsTopic` のリスト）
-* 画像サイズ・アスペクト比
-* ベース画像パス
-* 追加制約
-
-### ContextBuildResult
-
-* `PromptContext`
-* `CalendarEventItem` リスト（UI 表示用）
-* `NewsTopicItem` リスト（UI 表示用）
-
-`ContextService.BuildContextAsync()` の戻り値。
-
-### GeneratedImageInfo
-
-* ファイルパス
-* 生成日時
-* 使用プロンプト
-* サービスティア（`GoogleAiServiceTier`）
-* 元コンテキスト
-
-### HistoryItem
-
-* 実行日時
-* 成功 / 失敗
-* エラー概要
-* 適用画像パス
-* 使用したカレンダーイベント
-* 使用したニューストピック
-* サービスティア
-* スキップ済みフラグ（`IsSkipped`）
-
-### AvailableCalendar
-
-* カレンダー ID
-* 表示名
-* プライマリカレンダーかどうか
-* 選択状態（UI チェックボックス用）
-
-### GoogleAiServiceTier
-
-* `Standard`
-* `Flex`（失敗時 Standard にフォールバック）
-
-### PromptTemplate
-
-* テンプレート名
-* テンプレート本文
-
-### UpdateInfo
-
-* バージョン
-* リリース URL
-* ダウンロードパス
-* 確認日時
-* スキップフラグ
-
----
-
-## 実行フロー
-
-### GUI から手動生成する場合
-
-1. `MainWindowViewModel` から `GenerationCoordinator.RunAsync()` を呼ぶ
-2. `ContextService.BuildContextAsync()` で予定 / ニュースを取得し `ContextBuildResult` を返す
-3. `GoogleAiService.GenerateWallpaperAsync()` で画像生成（テキストプロンプト詳細化 → 画像生成の 2 ステップ）
-4. `WallpaperService` で壁紙を適用する
-5. `HistoryService` に結果を追記する
-6. ViewModel の ObservableCollection を更新して画面を更新する
-
-### CLI の `run-once` を実行する場合
-
-1. `CliCommands` から `GenerationCoordinator.RunScheduledAsync()` を呼ぶ
-2. スケジュール枠が未処理かを確認し、スキップ条件を評価する
-3. （生成対象の場合）上記 2〜5 と同様の処理を実行する
-4. 終了コードを返して終了する
-
-**処理本体は共通化する。**
-
----
-
-## 定期実行の考え方
-
-定期実行は **Windows Task Scheduler** を使う前提とする。GUI 上の「スケジューラ有効化」ボタンから `TaskSchedulerService` 経由でタスクの登録・削除が可能。
-
-### 方式の例
-
-* ログオン時実行
-* 1 日 1〜24 回（`SupportedRunsPerDay` = [1, 2, 3, 4, 6, 8, 12, 24]）
-
-スロット時刻の計算は `ScheduleHelper` が担う。
-
-### アプリ側でやること
-
-* `run-once` コマンドを用意する（`0` を成功、`1` を失敗として返す）
-* `TaskSchedulerService` でタスクを登録・削除する
-* `run-once` 呼び出し時に `SkipGenerationWhenNoChanges` でスキップ判定する
-
-### アプリ側でやらないこと
-
-* 常駐タイマー
-* トレイからの定期実行管理
-
----
-
-## ライブラリ
-
-### 採用しているもの
-
-| パッケージ | バージョン | 用途 |
-|-----------|----------|------|
-| `CommunityToolkit.Mvvm` | 8.4.2 | MVVM / `[ObservableProperty]` / `[RelayCommand]` |
-| `WPF-UI` | 4.2.0 | Fluent WPF コンポーネント |
-| `Kamishibai` / `Kamishibai.Hosting` | 3.1.0 | WPF + Generic Host 統合・DI |
-| `ConsoleAppFramework` | 5.x | CLI コマンドルーティング |
-| `Google_GenerativeAI` | 3.6.4 | Gemini API（テキスト＋画像生成） |
-| `Google.Apis.Calendar.v3` | 1.73.x | Google Calendar API |
-| `Microsoft.Extensions.Hosting` | 10.x | ホスティング・BackgroundService |
-| `Microsoft.Extensions.Http` | 10.x | `IHttpClientFactory` |
-| `Microsoft.Extensions.Http.Resilience` | 10.x | Polly リトライ |
-| `System.ServiceModel.Syndication` | 10.x | RSS フィード解析 |
-| `OpenGraph-Net` | 4.0.1 | OGP メタデータ解析 |
-| `Octokit` | 14.x | GitHub Releases API（更新チェック用） |
-| `Microsoft.Toolkit.Uwp.Notifications` | 7.1.3 | トースト通知 |
-| `Slions.VirtualDesktop.WPF` | 6.9.2 | 仮想デスクトップ別壁紙 |
-| `TaskScheduler` | 2.x | Windows Task Scheduler 操作 |
-| `Microsoft.Windows.CsWin32` | 0.3.x | Win32 API ラッパー生成 |
-| `Nito.AsyncEx.Coordination` | 5.1.2 | `AsyncLock` |
-
-### 採用していないもの
-
-* MediatR
-* ReactiveUI
-* AutoMapper
-* Repository パターン一式
-* 大規模ログ基盤
-* interface の大量定義
-
----
-
-## 実装ステップ（完了済み）
-
-### Step 1 ✅
-
-* WPF-UI で MainWindow を作る
-* Kamishibai で起動する
-* 設定保存 / 読み込みを作る
-
-### Step 2 ✅
-
-* `WallpaperService` を作る
-* 手動で画像を選んで壁紙適用できるようにする
-
-### Step 3 ✅
-
-* `ConsoleAppFramework` を導入する
-* `run-once` コマンドを先に作る
-* GUI と CLI の共存を成立させる
-
-### Step 4 ✅
-
-* Google AI 接続
-* 固定プロンプトで画像生成
-* 保存まで実装
-
-### Step 5 ✅
-
-* Google Calendar 接続
-* 予定取得
-* 画面表示
-
-### Step 6 ✅
-
-* RSS 取得
-* OGP メタデータ解析
-* 画面表示
-
-### Step 7 ✅
-
-* `GenerationCoordinator` で全体を接続する
-* `run-once` を完成させる
-* Task Scheduler 連動（`TaskSchedulerService`）
-
-### Step 8 ✅
-
-* Gemini 2 ステップ生成（テキストプロンプト詳細化 → 画像生成）
-* Flex / Standard サービスティア対応
-* 仮想デスクトップ別壁紙対応
-* `UpdateChecker`（GitHub Releases 自動チェック・トースト通知）
+* **Google AI API キー**: `PasswordVault`（Windows Credential Manager）で暗号化保管
+* **OAuth トークン**: `%LocalAppData%/StudioFreesia/WondayWall/calendar-token/` にキャッシュ
 
 ---
 
 ## 将来の拡張ポイント
-
-必要になった段階で追加する。
 
 * タスクトレイ常駐
 * 複数モニタ個別壁紙
 * `PromptBuilder` の分離
 * `ContextService` の分割（`CalendarService` / `NewsService`）
 * interface 導入
-
----
-
-## 方針まとめ
-
-* **常駐しない**
-* **同じ exe で GUI と CLI を両立する**
-* **WPF-UI + Kamishibai + ConsoleAppFramework を採用する**
-* **ViewModel は `MainWindowViewModel` 1 個**
-* **サービスは具体クラス直接参照（interface なし）**
-* **Task Scheduler 連動で定期実行する（`TaskSchedulerService` でアプリ内登録）**
-* **API キーは `PasswordVault` で暗号化保管**
-* **Gemini は 2 ステップ生成（テキストプロンプト詳細化 → 画像生成）**


### PR DESCRIPTION
## 変更内容

`dev.md` を現在の実装状況に合わせて更新しました。

### 主な変更点

#### 追加・更新されたサービス
- `HistoryService`（history.json 管理、最大 100 件）
- `TaskSchedulerService`（GUI からタスクスケジューラへの登録・削除）
- `UpdateChecker`（GitHub Releases API による自動更新チェック・トースト通知）

#### 追加されたモデル
- `ContextBuildResult`（`BuildContextAsync()` の戻り値）
- `PromptCalendarEvent` / `PromptNewsTopic`（プロンプト向けモデル）
- `AvailableCalendar`、`GoogleAiServiceTier`、`PromptTemplate`、`UpdateInfo`

#### 実装の変化を反映
- Google AI の 2 ステップ生成（テキストプロンプト詳細化 → 画像生成）
- Flex / Standard サービスティア対応（Flex 失敗時は Standard にフォールバック）
- 仮想デスクトップ別壁紙対応（実装済みに更新）
- API キーの `PasswordVault` 暗号化保管
- `SkipGenerationWhenNoChanges` / `UpdateLockScreen` オプション
- Google Search グラウンディング（プロンプト詳細化ステップ）
- Polly リトライ戦略（HttpClient レジリエンス）

#### フォルダ構成・パッケージ一覧の更新
- `ComponentModel/`、`Utils/` の実際のファイル構成に更新
- 使用中のすべての NuGet パッケージをバージョン付きで記載

#### 実装順序
- 完了済みのステップをすべてチェックマーク付きで記載
- Step 8（2 ステップ生成・仮想デスクトップ・更新チェック）を追加

#### 将来の拡張ポイント
- 実装済み項目（仮想デスクトップ）を削除
- 未実装項目のみ残した