### PR TITLE
fix: AppxManifest の言語コードを ja-JP/en-US から ja/en に修正

### DIFF
--- a/WondayWall.Package/AppxManifest.xml
+++ b/WondayWall.Package/AppxManifest.xml
@@ -24,8 +24,8 @@
   </Dependencies>
 
   <Resources>
-    <Resource Language="ja-JP" />
-    <Resource Language="en-US" />
+    <Resource Language="ja" />
+    <Resource Language="en" />
   </Resources>
 
   <Applications>


### PR DESCRIPTION
## 変更内容

`WondayWall.Package/AppxManifest.xml` の `<Resource Language>` 属性を修正。

| Before | After |
|--------|-------|
| `ja-JP` | `ja` |
| `en-US` | `en` |

MSIX パッケージングツールが要求する言語コード形式に合わせるため、地域サブタグを除いた言語コードに統一。