### PR TITLE
[codex] AndroidアプリのGitHub Actionsビルドを追加

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   build:
     name: Build Android release APK
-    if: ${{ inputs.publish-artifact != true }}
+    if: ${{ github.event_name != 'pull_request' && inputs.publish-artifact != true }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -124,7 +124,7 @@ jobs:
 
   release-apk:
     name: Build signed Android release APK
-    if: ${{ inputs.publish-artifact == true }}
+    if: ${{ github.event_name == 'pull_request' || inputs.publish-artifact == true }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: android-release

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,6 +3,15 @@ name: Android
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      ANDROID_KEYSTORE_BASE64:
+        required: true
+      ANDROID_KEYSTORE_PASSWORD:
+        required: true
+      ANDROID_KEY_ALIAS:
+        required: true
+      ANDROID_KEY_PASSWORD:
+        required: true
   push:
     branches: [main]
     paths:
@@ -98,14 +107,54 @@ jobs:
         with:
           gradle-version: ${{ steps.gradle-version.outputs.version }}
 
-      - name: Build APK and app bundle
+      - name: Restore release signing key
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          missing=0
+          for name in ANDROID_KEYSTORE_BASE64 ANDROID_KEYSTORE_PASSWORD ANDROID_KEY_ALIAS ANDROID_KEY_PASSWORD; do
+            if [ -z "${!name}" ]; then
+              echo "::error::$name secret is required to build a signed release APK."
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+          keystore_file="$RUNNER_TEMP/wondaywall-release.jks"
+          printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$keystore_file"
+          echo "ANDROID_KEYSTORE_FILE=$keystore_file" >> "$GITHUB_ENV"
+
+      - name: Build signed release APK
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: |
           gradle --no-daemon \
             -PwondaywallVersionCode=${{ steps.android-version.outputs.version-code }} \
             "-PwondaywallVersionName=${{ steps.android-version.outputs.version-name }}" \
-            :app:assembleDebug \
-            :app:assembleRelease \
-            :app:bundleRelease
+            :app:assembleRelease
+
+      - name: Verify signed APK
+        run: |
+          apk_path="app/build/outputs/apk/release/app-release.apk"
+          if [ ! -f "$apk_path" ]; then
+            echo "::error::Signed release APK was not found: $apk_path"
+            exit 1
+          fi
+
+          apksigner=$(find "$ANDROID_HOME/build-tools" -name apksigner -type f | sort -V | tail -n 1)
+          if [ -z "$apksigner" ]; then
+            echo "::error::apksigner was not found in $ANDROID_HOME/build-tools."
+            exit 1
+          fi
+
+          "$apksigner" verify --print-certs "$apk_path"
 
       - name: Prepare artifacts
         id: prepare-artifacts
@@ -115,12 +164,8 @@ jobs:
           artifact_dir="build/github-artifacts"
           mkdir -p "$artifact_dir"
 
-          cp app/build/outputs/apk/debug/app-debug.apk \
-            "$artifact_dir/WondayWall-Android-debug-$version_label.apk"
-          cp app/build/outputs/apk/release/app-release-unsigned.apk \
-            "$artifact_dir/WondayWall-Android-release-unsigned-$version_label.apk"
-          cp app/build/outputs/bundle/release/app-release.aab \
-            "$artifact_dir/WondayWall-Android-release-$version_label.aab"
+          cp app/build/outputs/apk/release/app-release.apk \
+            "$artifact_dir/WondayWall-Android-$version_label.apk"
 
           (cd "$artifact_dir" && sha256sum * > SHA256SUMS.txt)
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,16 +2,16 @@ name: Android
 
 on:
   workflow_dispatch:
+    inputs:
+      publish-artifact:
+        description: "Build and upload the signed release APK artifact."
+        type: boolean
+        default: true
   workflow_call:
-    secrets:
-      ANDROID_KEYSTORE_BASE64:
-        required: true
-      ANDROID_KEYSTORE_PASSWORD:
-        required: true
-      ANDROID_KEY_ALIAS:
-        required: true
-      ANDROID_KEY_PASSWORD:
-        required: true
+    inputs:
+      publish-artifact:
+        type: boolean
+        default: true
   push:
     branches: [main]
     paths:
@@ -31,9 +31,103 @@ concurrency:
 
 jobs:
   build:
-    name: Build Android app
+    name: Build Android release APK
+    if: ${{ inputs.publish-artifact != true }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: WondayWall.Android
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - uses: gittools/actions/gitversion/setup@v4.5.0
+        with:
+          versionSpec: "6.x"
+
+      - id: gitversion
+        uses: gittools/actions/gitversion/execute@v4.5.0
+
+      - name: Resolve Android version
+        id: android-version
+        run: |
+          file_version="${{ steps.gitversion.outputs.assemblySemFileVer }}"
+          IFS='.' read -r major minor patch revision <<< "$file_version"
+
+          for part in "$major" "$minor" "$patch" "$revision"; do
+            if ! [[ "$part" =~ ^[0-9]+$ ]]; then
+              echo "Invalid GitVersion assemblySemFileVer: $file_version" >&2
+              exit 1
+            fi
+          done
+
+          if [ "$minor" -gt 99 ] || [ "$patch" -gt 99 ] || [ "$revision" -gt 99 ]; then
+            echo "GitVersion assemblySemFileVer is too large for Android versionCode packing: $file_version" >&2
+            exit 1
+          fi
+
+          version_code=$((major * 1000000 + minor * 10000 + patch * 100 + revision))
+          if [ "$version_code" -lt 1 ] || [ "$version_code" -gt 2100000000 ]; then
+            echo "Android versionCode is out of range: $version_code" >&2
+            exit 1
+          fi
+
+          echo "version-code=$version_code" >> "$GITHUB_OUTPUT"
+          echo "version-name=${{ steps.gitversion.outputs.fullSemVer }}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android SDK packages
+        run: sdkmanager "platforms;android-37.0"
+
+      - name: Resolve Gradle version
+        id: gradle-version
+        run: |
+          version=$(sed -n 's#.*gradle-\([^-]*\)-bin.zip#\1#p' gradle/wrapper/gradle-wrapper.properties)
+          if [ -z "$version" ]; then
+            echo "Gradle version could not be resolved from gradle-wrapper.properties." >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: ${{ steps.gradle-version.outputs.version }}
+
+      - name: Build release APK
+        run: |
+          gradle --no-daemon \
+            -PwondaywallVersionCode=${{ steps.android-version.outputs.version-code }} \
+            "-PwondaywallVersionName=${{ steps.android-version.outputs.version-name }}" \
+            :app:assembleRelease
+
+      - name: Verify release APK output
+        run: |
+          signed_apk="app/build/outputs/apk/release/app-release.apk"
+          unsigned_apk="app/build/outputs/apk/release/app-release-unsigned.apk"
+          if [ ! -f "$signed_apk" ] && [ ! -f "$unsigned_apk" ]; then
+            echo "::error::Release APK was not found."
+            exit 1
+          fi
+
+  release-apk:
+    name: Build signed Android release APK
+    if: ${{ inputs.publish-artifact == true }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment: android-release
     permissions:
       contents: read
     defaults:
@@ -108,6 +202,7 @@ jobs:
           gradle-version: ${{ steps.gradle-version.outputs.version }}
 
       - name: Restore release signing key
+        id: release-signing
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
@@ -128,8 +223,9 @@ jobs:
           keystore_file="$RUNNER_TEMP/wondaywall-release.jks"
           printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$keystore_file"
           echo "ANDROID_KEYSTORE_FILE=$keystore_file" >> "$GITHUB_ENV"
+          echo "signed=true" >> "$GITHUB_OUTPUT"
 
-      - name: Build signed release APK
+      - name: Build release APK
         env:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,16 +2,7 @@ name: Android
 
 on:
   workflow_dispatch:
-    inputs:
-      publish-artifact:
-        description: "Build and upload the signed release APK artifact."
-        type: boolean
-        default: true
   workflow_call:
-    inputs:
-      publish-artifact:
-        type: boolean
-        default: true
   push:
     branches: [main]
     paths:
@@ -30,101 +21,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build Android release APK
-    if: ${{ github.event_name != 'pull_request' && inputs.publish-artifact != true }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      contents: read
-    defaults:
-      run:
-        working-directory: WondayWall.Android
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: "21"
-
-      - uses: gittools/actions/gitversion/setup@v4.5.0
-        with:
-          versionSpec: "6.x"
-
-      - id: gitversion
-        uses: gittools/actions/gitversion/execute@v4.5.0
-
-      - name: Resolve Android version
-        id: android-version
-        run: |
-          file_version="${{ steps.gitversion.outputs.assemblySemFileVer }}"
-          IFS='.' read -r major minor patch revision <<< "$file_version"
-
-          for part in "$major" "$minor" "$patch" "$revision"; do
-            if ! [[ "$part" =~ ^[0-9]+$ ]]; then
-              echo "Invalid GitVersion assemblySemFileVer: $file_version" >&2
-              exit 1
-            fi
-          done
-
-          if [ "$minor" -gt 99 ] || [ "$patch" -gt 99 ] || [ "$revision" -gt 99 ]; then
-            echo "GitVersion assemblySemFileVer is too large for Android versionCode packing: $file_version" >&2
-            exit 1
-          fi
-
-          version_code=$((major * 1000000 + minor * 10000 + patch * 100 + revision))
-          if [ "$version_code" -lt 1 ] || [ "$version_code" -gt 2100000000 ]; then
-            echo "Android versionCode is out of range: $version_code" >&2
-            exit 1
-          fi
-
-          echo "version-code=$version_code" >> "$GITHUB_OUTPUT"
-          echo "version-name=${{ steps.gitversion.outputs.fullSemVer }}" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
-
-      - name: Install Android SDK packages
-        run: sdkmanager "platforms;android-37.0"
-
-      - name: Resolve Gradle version
-        id: gradle-version
-        run: |
-          version=$(sed -n 's#.*gradle-\([^-]*\)-bin.zip#\1#p' gradle/wrapper/gradle-wrapper.properties)
-          if [ -z "$version" ]; then
-            echo "Gradle version could not be resolved from gradle-wrapper.properties." >&2
-            exit 1
-          fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          gradle-version: ${{ steps.gradle-version.outputs.version }}
-
-      - name: Build release APK
-        run: |
-          gradle --no-daemon \
-            -PwondaywallVersionCode=${{ steps.android-version.outputs.version-code }} \
-            "-PwondaywallVersionName=${{ steps.android-version.outputs.version-name }}" \
-            :app:assembleRelease
-
-      - name: Verify release APK output
-        run: |
-          signed_apk="app/build/outputs/apk/release/app-release.apk"
-          unsigned_apk="app/build/outputs/apk/release/app-release-unsigned.apk"
-          if [ ! -f "$signed_apk" ] && [ ! -f "$unsigned_apk" ]; then
-            echo "::error::Release APK was not found."
-            exit 1
-          fi
-
   release-apk:
     name: Build signed Android release APK
-    if: ${{ github.event_name == 'pull_request' || inputs.publish-artifact == true }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: android-release

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -124,7 +124,7 @@ jobs:
 
           (cd "$artifact_dir" && sha256sum * > SHA256SUMS.txt)
 
-          artifact_name="WondayWall-Android-${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
+          artifact_name="WondayWall-Android-$version_label"
           echo "artifact-name=$artifact_name" >> "$GITHUB_OUTPUT"
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -81,7 +81,7 @@ jobs:
         uses: android-actions/setup-android@v3
 
       - name: Install Android SDK packages
-        run: sdkmanager "platforms;android-37"
+        run: sdkmanager "platforms;android-37.0"
 
       - name: Resolve Gradle version
         id: gradle-version

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,133 @@
+name: Android
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  push:
+    branches: [main]
+    paths:
+      - "WondayWall.Android/**"
+      - "GitVersion.yml"
+      - ".github/workflows/android.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "WondayWall.Android/**"
+      - "GitVersion.yml"
+      - ".github/workflows/android.yml"
+
+concurrency:
+  group: android-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Android app
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: WondayWall.Android
+    outputs:
+      artifact-name: ${{ steps.prepare-artifacts.outputs.artifact-name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - uses: gittools/actions/gitversion/setup@v4.5.0
+        with:
+          versionSpec: "6.x"
+
+      - id: gitversion
+        uses: gittools/actions/gitversion/execute@v4.5.0
+
+      - name: Resolve Android version
+        id: android-version
+        run: |
+          file_version="${{ steps.gitversion.outputs.assemblySemFileVer }}"
+          IFS='.' read -r major minor patch revision <<< "$file_version"
+
+          for part in "$major" "$minor" "$patch" "$revision"; do
+            if ! [[ "$part" =~ ^[0-9]+$ ]]; then
+              echo "Invalid GitVersion assemblySemFileVer: $file_version" >&2
+              exit 1
+            fi
+          done
+
+          if [ "$minor" -gt 99 ] || [ "$patch" -gt 99 ] || [ "$revision" -gt 99 ]; then
+            echo "GitVersion assemblySemFileVer is too large for Android versionCode packing: $file_version" >&2
+            exit 1
+          fi
+
+          version_code=$((major * 1000000 + minor * 10000 + patch * 100 + revision))
+          if [ "$version_code" -lt 1 ] || [ "$version_code" -gt 2100000000 ]; then
+            echo "Android versionCode is out of range: $version_code" >&2
+            exit 1
+          fi
+
+          echo "version-code=$version_code" >> "$GITHUB_OUTPUT"
+          echo "version-name=${{ steps.gitversion.outputs.fullSemVer }}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android SDK packages
+        run: sdkmanager "platforms;android-37"
+
+      - name: Resolve Gradle version
+        id: gradle-version
+        run: |
+          version=$(sed -n 's#.*gradle-\([^-]*\)-bin.zip#\1#p' gradle/wrapper/gradle-wrapper.properties)
+          if [ -z "$version" ]; then
+            echo "Gradle version could not be resolved from gradle-wrapper.properties." >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: ${{ steps.gradle-version.outputs.version }}
+
+      - name: Build APK and app bundle
+        run: |
+          gradle --no-daemon \
+            -PwondaywallVersionCode=${{ steps.android-version.outputs.version-code }} \
+            "-PwondaywallVersionName=${{ steps.android-version.outputs.version-name }}" \
+            :app:assembleDebug \
+            :app:assembleRelease \
+            :app:bundleRelease
+
+      - name: Prepare artifacts
+        id: prepare-artifacts
+        run: |
+          version_label="${{ steps.gitversion.outputs.fullSemVer }}"
+
+          artifact_dir="build/github-artifacts"
+          mkdir -p "$artifact_dir"
+
+          cp app/build/outputs/apk/debug/app-debug.apk \
+            "$artifact_dir/WondayWall-Android-debug-$version_label.apk"
+          cp app/build/outputs/apk/release/app-release-unsigned.apk \
+            "$artifact_dir/WondayWall-Android-release-unsigned-$version_label.apk"
+          cp app/build/outputs/bundle/release/app-release.aab \
+            "$artifact_dir/WondayWall-Android-release-$version_label.aab"
+
+          (cd "$artifact_dir" && sha256sum * > SHA256SUMS.txt)
+
+          artifact_name="WondayWall-Android-${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
+          echo "artifact-name=$artifact_name" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.prepare-artifacts.outputs.artifact-name }}
+          path: WondayWall.Android/build/github-artifacts/

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,14 +1,21 @@
 name: .NET Desktop
 
 on:
+  workflow_call:
+    inputs:
+      include-installers:
+        description: "Release 用のインストーラー成果物も作成する"
+        required: false
+        type: boolean
+        default: false
   push:
     branches: [main]
-    tags: ["*.*.*", "v*.*.*"]
     paths:
       - "WondayWall/**"
       - "WondayWall.Package/**"
       - "WondayWall.Wix/**"
       - "WondayWall.sln"
+      - "GitVersion.yml"
       - ".config/**"
       - "eng/**"
       - ".github/workflows/dotnet-desktop.yml"
@@ -19,6 +26,7 @@ on:
       - "WondayWall.Package/**"
       - "WondayWall.Wix/**"
       - "WondayWall.sln"
+      - "GitVersion.yml"
       - ".config/**"
       - "eng/**"
       - ".github/workflows/dotnet-desktop.yml"
@@ -108,7 +116,7 @@ jobs:
           versionSpec: "6.x"
       - id: gitversion
         uses: gittools/actions/gitversion/execute@v4.5.0
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@v4
         with:
           name: licenses
           path: publish\licenses
@@ -133,7 +141,7 @@ jobs:
           path: publish\
 
   installer:
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ inputs.include-installers == true }}
     needs:
       - build
     runs-on: windows-latest
@@ -141,30 +149,36 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/cache@v4
         with:
           path: ${{ env.NUGET_PACKAGES }}
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json', '**/*.csproj', '**/*.wixproj', '.config/dotnet-tools.json', 'eng/licenses/*.json', 'Directory.Packages.props', 'Directory.Build.props', 'NuGet.config', 'global.json') }}
           restore-keys: |
             ${{ runner.os }}-nuget-
+
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 10.0.x
+
       # WondayWall-full-* は SelfContained=true のビルド成果物
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
           pattern: WondayWall-full-*
           merge-multiple: true
+
       - name: Verify THIRD-PARTY-NOTICES.md in artifacts
         run: |
           if (!(Test-Path "artifacts\licenses\THIRD-PARTY-NOTICES.md")) {
             throw "THIRD-PARTY-NOTICES.md was not found in artifacts."
           }
+
       - run: |
           dotnet run --project WondayWall.Wix.csproj -c Release
           dotnet build WondayWall.Installer.wixproj -p:OutputName=WondayWall-${{ needs.build.outputs.version }}
         working-directory: WondayWall.Wix
+
       - name: Generate MSIX
         shell: pwsh
         run: |
@@ -207,38 +221,13 @@ jobs:
           }
 
           Write-Host "MSIX generated: publish\WondayWall-$version.msix"
+
       - uses: actions/upload-artifact@v4
         with:
           name: WondayWall-${{ needs.build.outputs.version }}.msi
           path: publish\*.msi
+
       - uses: actions/upload-artifact@v4
         with:
           name: WondayWall-${{ needs.build.outputs.version }}.msix
           path: publish\*.msix
-
-  release:
-    if: ${{ success() && startsWith(github.ref, 'refs/tags/') }}
-    needs:
-      - installer
-      - build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/download-artifact@v4
-      - run: |
-          for dir in WondayWall-*/; do
-            base=$(basename "$dir")
-            if ! find "$dir" -maxdepth 1 -type f \( -name "*.msi" -o -name "*.msix" \) | read; then
-              (cd "$dir" && zip -r "../${base}.zip" .)
-            fi
-          done
-      - uses: softprops/action-gh-release@v3.0.0
-        with:
-          generate_release_notes: true
-          draft: true
-          prerelease: false
-          files: |
-            WondayWall-*.zip
-            WondayWall-*.msi/WondayWall-*.msi
-            WondayWall-*.msix/WondayWall-*.msix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,6 @@ jobs:
   android:
     name: Build Android release assets
     uses: ./.github/workflows/android.yml
-    with:
-      publish-artifact: true
 
   release:
     name: Create draft release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+on:
+  push:
+    tags: ["*.*.*", "v*.*.*"]
+
+permissions:
+  contents: read
+
+jobs:
+  desktop:
+    name: Build desktop release assets
+    uses: ./.github/workflows/dotnet-desktop.yml
+    with:
+      include-installers: true
+
+  android:
+    name: Build Android release assets
+    uses: ./.github/workflows/android.yml
+
+  release:
+    name: Create draft release
+    needs:
+      - desktop
+      - android
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+
+      - name: Prepare release files
+        run: |
+          mkdir -p release-files
+
+          for dir in release-artifacts/WondayWall-*/; do
+            [ -d "$dir" ] || continue
+            base=$(basename "$dir")
+            case "$base" in
+              WondayWall-Android-*)
+                continue
+                ;;
+            esac
+
+            if find "$dir" -maxdepth 1 -type f \( -name "*.msi" -o -name "*.msix" \) | read; then
+              continue
+            fi
+
+            (cd "$dir" && zip -r "$GITHUB_WORKSPACE/release-files/${base}.zip" .)
+          done
+
+          cp release-artifacts/WondayWall-*.msi/*.msi release-files/
+          cp release-artifacts/WondayWall-*.msix/*.msix release-files/
+          cp release-artifacts/WondayWall-Android-*/* release-files/
+
+      - uses: softprops/action-gh-release@v3.0.0
+        with:
+          generate_release_notes: true
+          draft: true
+          prerelease: false
+          files: release-files/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
   android:
     name: Build Android release assets
     uses: ./.github/workflows/android.yml
+    secrets: inherit
 
   release:
     name: Create draft release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,8 @@ jobs:
   android:
     name: Build Android release assets
     uses: ./.github/workflows/android.yml
-    secrets: inherit
+    with:
+      publish-artifact: true
 
   release:
     name: Create draft release

--- a/WondayWall.Android/app/build.gradle.kts
+++ b/WondayWall.Android/app/build.gradle.kts
@@ -6,6 +6,17 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
+val releaseKeystoreFile = providers.environmentVariable("ANDROID_KEYSTORE_FILE").orNull
+val releaseKeystorePassword = providers.environmentVariable("ANDROID_KEYSTORE_PASSWORD").orNull
+val releaseKeyAlias = providers.environmentVariable("ANDROID_KEY_ALIAS").orNull
+val releaseKeyPassword = providers.environmentVariable("ANDROID_KEY_PASSWORD").orNull
+val hasReleaseSigningConfig = listOf(
+    releaseKeystoreFile,
+    releaseKeystorePassword,
+    releaseKeyAlias,
+    releaseKeyPassword
+).all { !it.isNullOrBlank() }
+
 configure<ApplicationExtension> {
     namespace = "com.studiofreesia.wondaywall"
     compileSdk = 37
@@ -25,8 +36,22 @@ configure<ApplicationExtension> {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    if (hasReleaseSigningConfig) {
+        signingConfigs {
+            create("release") {
+                storeFile = file(releaseKeystoreFile!!)
+                storePassword = releaseKeystorePassword
+                keyAlias = releaseKeyAlias
+                keyPassword = releaseKeyPassword
+            }
+        }
+    }
+
     buildTypes {
         release {
+            if (hasReleaseSigningConfig) {
+                signingConfig = signingConfigs.getByName("release")
+            }
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),

--- a/WondayWall.Android/app/build.gradle.kts
+++ b/WondayWall.Android/app/build.gradle.kts
@@ -14,8 +14,13 @@ configure<ApplicationExtension> {
         applicationId = "com.studiofreesia.wondaywall"
         minSdk = 26
         targetSdk = 37
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = providers.gradleProperty("wondaywallVersionCode")
+            .orElse("2100000000")
+            .get()
+            .toInt()
+        versionName = providers.gradleProperty("wondaywallVersionName")
+            .orElse("0.0")
+            .get()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/WondayWall.Android/app/build.gradle.kts
+++ b/WondayWall.Android/app/build.gradle.kts
@@ -52,7 +52,8 @@ configure<ApplicationExtension> {
             if (hasReleaseSigningConfig) {
                 signingConfig = signingConfigs.getByName("release")
             }
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
@@ -75,6 +76,8 @@ configure<ApplicationExtension> {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
             excludes += "/META-INF/INDEX.LIST"
             excludes += "/META-INF/DEPENDENCIES"
+            // Google GenAI の shaded KotlinModule 参照が未変換の service entry を除外する。
+            excludes += "/META-INF/services/com.fasterxml.jackson.databind.Module"
         }
     }
 }

--- a/WondayWall.Android/app/proguard-rules.pro
+++ b/WondayWall.Android/app/proguard-rules.pro
@@ -1,2 +1,5 @@
 # WondayWall プロジェクト固有の ProGuard ルール
 # デフォルトのルールはビルドツールが自動生成するため、ここでは追加ルールのみ記載する。
+
+# Google GenAI の service entry が shading 前の KotlinModule を参照するため、R8 の警告を抑制する。
+-dontwarn com.fasterxml.jackson.module.kotlin.**

--- a/WondayWall.Android/app/proguard-rules.pro
+++ b/WondayWall.Android/app/proguard-rules.pro
@@ -2,8 +2,9 @@
 # デフォルトのルールはビルドツールが自動生成するため、ここでは追加ルールのみ記載する。
 
 # Google GenAI SDK は Jackson で SDK モデルを JSON 変換するため、
-# R8 によるクラス削除・難読化でデシリアライズが壊れないよう保持する。
+# R8 によるクラス削除・難読化でデシリアライズや型変換が壊れないよう保持する。
 -keepattributes Signature,*Annotation*,InnerClasses,EnclosingMethod,MethodParameters
+-keep class com.google.genai.* { *; }
 -keep class com.google.genai.JsonSerializable { *; }
 -keep class com.google.genai.JsonSerializable$* { *; }
 -keep class com.google.genai.errors.** { *; }

--- a/WondayWall.Android/app/proguard-rules.pro
+++ b/WondayWall.Android/app/proguard-rules.pro
@@ -1,5 +1,13 @@
 # WondayWall プロジェクト固有の ProGuard ルール
 # デフォルトのルールはビルドツールが自動生成するため、ここでは追加ルールのみ記載する。
 
+# Google GenAI SDK は Jackson で SDK モデルを JSON 変換するため、
+# R8 によるクラス削除・難読化でデシリアライズが壊れないよう保持する。
+-keepattributes Signature,*Annotation*,InnerClasses,EnclosingMethod,MethodParameters
+-keep class com.google.genai.JsonSerializable { *; }
+-keep class com.google.genai.JsonSerializable$* { *; }
+-keep class com.google.genai.errors.** { *; }
+-keep class com.google.genai.types.** { *; }
+
 # Google GenAI の service entry が shading 前の KotlinModule を参照するため、R8 の警告を抑制する。
 -dontwarn com.fasterxml.jackson.module.kotlin.**

--- a/WondayWall.Android/app/proguard-rules.pro
+++ b/WondayWall.Android/app/proguard-rules.pro
@@ -9,7 +9,8 @@
 -keep class com.google.genai.JsonSerializable$* { *; }
 -keep class com.google.genai.errors.** { *; }
 -keep class com.google.genai.types.** { *; }
-# Jackson TypeReference の匿名クラスは generic superclass 情報が実行時に必要。
+# Jackson TypeReference は親クラスの型パラメータと匿名クラスの generic superclass 情報が実行時に必要。
+-keep class com.fasterxml.jackson.core.type.TypeReference { *; }
 -keep class * extends com.fasterxml.jackson.core.type.TypeReference { *; }
 
 # Google GenAI の service entry が shading 前の KotlinModule を参照するため、R8 の警告を抑制する。

--- a/WondayWall.Android/app/proguard-rules.pro
+++ b/WondayWall.Android/app/proguard-rules.pro
@@ -8,6 +8,8 @@
 -keep class com.google.genai.JsonSerializable$* { *; }
 -keep class com.google.genai.errors.** { *; }
 -keep class com.google.genai.types.** { *; }
+# Jackson TypeReference の匿名クラスは generic superclass 情報が実行時に必要。
+-keep class * extends com.fasterxml.jackson.core.type.TypeReference { *; }
 
 # Google GenAI の service entry が shading 前の KotlinModule を参照するため、R8 の警告を抑制する。
 -dontwarn com.fasterxml.jackson.module.kotlin.**

--- a/WondayWall.Android/app/src/main/kotlin/com/studiofreesia/wondaywall/services/GenerationCoordinator.kt
+++ b/WondayWall.Android/app/src/main/kotlin/com/studiofreesia/wondaywall/services/GenerationCoordinator.kt
@@ -1,6 +1,7 @@
 package com.studiofreesia.wondaywall.services
 
 import android.content.Context
+import android.util.Log
 import com.studiofreesia.wondaywall.models.GoogleAiServiceTier
 import com.studiofreesia.wondaywall.models.HistoryItem
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -58,7 +59,7 @@ class GenerationCoordinator(
                     serviceTier = GoogleAiServiceTier.Flex,
                     isSkipped = true,
                 )
-                historyService.addHistoryItem(skippedItem)
+                recordHistoryItem(skippedItem)
                 return@withLock skippedItem
             }
 
@@ -112,7 +113,7 @@ class GenerationCoordinator(
                 serviceTier = serviceTier,
                 usedPrompt = config.userPrompt.takeIf { it.isNotEmpty() },
             )
-            historyService.addHistoryItem(historyItem)
+            recordHistoryItem(historyItem)
 
             // 通知を送る
             if (config.showNotification) {
@@ -134,12 +135,19 @@ class GenerationCoordinator(
                 usedNewsTopics = null,
                 serviceTier = serviceTier,
             )
-            historyService.addHistoryItem(historyItem)
+            recordHistoryItem(historyItem)
 
             if (config.showNotification) {
                 notificationHelper.showFailureNotification(historyItem.errorSummary ?: "不明なエラー")
             }
             historyItem
+        }
+    }
+
+    // 生成結果を履歴に保存する。保存失敗は生成処理自体の戻り値を壊さず、ログに残す。
+    private suspend fun recordHistoryItem(item: HistoryItem) {
+        if (!historyService.addHistoryItem(item)) {
+            Log.e(TAG, "生成履歴の保存に失敗しました")
         }
     }
 
@@ -179,5 +187,9 @@ class GenerationCoordinator(
         val powerManager = context.getSystemService(Context.POWER_SERVICE)
             as android.os.PowerManager
         return powerManager.isPowerSaveMode
+    }
+
+    companion object {
+        private const val TAG = "GenerationCoordinator"
     }
 }

--- a/WondayWall.Android/app/src/main/kotlin/com/studiofreesia/wondaywall/services/HistoryService.kt
+++ b/WondayWall.Android/app/src/main/kotlin/com/studiofreesia/wondaywall/services/HistoryService.kt
@@ -1,8 +1,13 @@
 package com.studiofreesia.wondaywall.services
 
 import android.content.Context
+import android.util.Log
 import com.studiofreesia.wondaywall.models.HistoryItem
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -13,6 +18,8 @@ import java.io.File
 class HistoryService(context: Context) {
 
     private val historyFile = File(context.filesDir, "history.json")
+    private val _historyChanges = MutableStateFlow(0L)
+    val historyChanges: StateFlow<Long> = _historyChanges.asStateFlow()
 
     private val json = Json {
         ignoreUnknownKeys = true
@@ -26,25 +33,32 @@ class HistoryService(context: Context) {
             val text = historyFile.readText()
             json.decodeFromString<List<HistoryItem>>(text)
         } catch (e: Exception) {
+            Log.e(TAG, "履歴の読み込みに失敗しました", e)
             emptyList()
         }
     }
 
     // 履歴一覧を保存する
-    private suspend fun saveHistory(items: List<HistoryItem>) = withContext(Dispatchers.IO) {
+    private suspend fun saveHistory(items: List<HistoryItem>): Boolean = withContext(Dispatchers.IO) {
         try {
             val text = json.encodeToString(items)
             historyFile.writeText(text)
+            true
         } catch (e: Exception) {
-            // 保存エラーは無視する
+            Log.e(TAG, "履歴の保存に失敗しました", e)
+            false
         }
     }
 
     // 履歴に1件追加する（先頭に追加、最大100件）
-    suspend fun addHistoryItem(item: HistoryItem) {
+    suspend fun addHistoryItem(item: HistoryItem): Boolean {
         val existing = loadHistory().toMutableList()
         existing.add(0, item)
-        saveHistory(existing.take(100))
+        val saved = saveHistory(existing.take(100))
+        if (saved) {
+            _historyChanges.update { it + 1 }
+        }
+        return saved
     }
 
     // 最新の成功履歴を取得する
@@ -52,14 +66,22 @@ class HistoryService(context: Context) {
         loadHistory().firstOrNull { it.isSuccess && !it.isSkipped }
 
     // 指定IDの履歴を削除する
-    suspend fun deleteHistoryItem(id: String) {
+    suspend fun deleteHistoryItem(id: String): Boolean {
         val existing = loadHistory().filter { it.id != id }
-        saveHistory(existing)
+        val saved = saveHistory(existing)
+        if (saved) {
+            _historyChanges.update { it + 1 }
+        }
+        return saved
     }
 
     // 最後に成功した生成時刻をエポックミリ秒で取得する（スロット判定用）
     suspend fun getLastSuccessTimeMillis(): Long? {
         val item = getLatestSuccessItem() ?: return null
         return item.executedAt.toEpochMilliseconds()
+    }
+
+    companion object {
+        private const val TAG = "HistoryService"
     }
 }

--- a/WondayWall.Android/app/src/main/kotlin/com/studiofreesia/wondaywall/ui/screens/history/HistoryViewModel.kt
+++ b/WondayWall.Android/app/src/main/kotlin/com/studiofreesia/wondaywall/ui/screens/history/HistoryViewModel.kt
@@ -34,7 +34,11 @@ class HistoryViewModel(
     val uiState: StateFlow<HistoryUiState> = _uiState.asStateFlow()
 
     init {
-        loadHistory()
+        viewModelScope.launch {
+            historyService.historyChanges.collect {
+                refreshHistory()
+            }
+        }
         viewModelScope.launch {
             generationCoordinator.isGenerating.collect { generating ->
                 _uiState.value = _uiState.value.copy(isGenerating = generating)
@@ -45,14 +49,18 @@ class HistoryViewModel(
     // 履歴を読み込む
     fun loadHistory() {
         viewModelScope.launch {
-            val history = historyService.loadHistory()
-            val config = appConfigService.getConfig()
-            _uiState.value = _uiState.value.copy(
-                historyItems = history,
-                config = config,
-                errorMessage = null,
-            )
+            refreshHistory()
         }
+    }
+
+    private suspend fun refreshHistory() {
+        val history = historyService.loadHistory()
+        val config = appConfigService.getConfig()
+        _uiState.value = _uiState.value.copy(
+            historyItems = history,
+            config = config,
+            errorMessage = null,
+        )
     }
 
     // 履歴アイテムを削除する

--- a/WondayWall.Android/app/src/main/kotlin/com/studiofreesia/wondaywall/ui/screens/home/HomeViewModel.kt
+++ b/WondayWall.Android/app/src/main/kotlin/com/studiofreesia/wondaywall/ui/screens/home/HomeViewModel.kt
@@ -40,7 +40,11 @@ class HomeViewModel(
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
 
     init {
-        loadData()
+        viewModelScope.launch {
+            historyService.historyChanges.collect {
+                refreshData()
+            }
+        }
         // 生成中フラグを監視する
         viewModelScope.launch {
             generationCoordinator.isGenerating.collect { isGenerating ->
@@ -52,14 +56,18 @@ class HomeViewModel(
     // 画面データを読み込む
     fun loadData() {
         viewModelScope.launch {
-            val history = historyService.loadHistory()
-            val config = appConfigService.getConfig()
-            _uiState.value = _uiState.value.copy(
-                latestHistoryItem = history.firstOrNull { !it.isSkipped },
-                config = config,
-                errorMessage = null,
-            )
+            refreshData()
         }
+    }
+
+    private suspend fun refreshData() {
+        val history = historyService.loadHistory()
+        val config = appConfigService.getConfig()
+        _uiState.value = _uiState.value.copy(
+            latestHistoryItem = history.firstOrNull { !it.isSkipped },
+            config = config,
+            errorMessage = null,
+        )
     }
 
     // 今すぐ生成を実行する


### PR DESCRIPTION
## 概要

- Fixes #135
- Android のリリースビルドを GitVersion ベースに統一し、.NET と同じバージョン番号を使うようにしました。
- PR / release で署名済み release APK だけを成果物にし、debug APK / AAB / 未署名 APK の成果物と CI ジョブを削除しました。
- Android 署名情報は `android-release` environment の secret / variable から読むようにし、iOS と同様に秘匿情報を環境へ分離しました。
- release APK は `minify` / resource shrink を有効化し、Google GenAI SDK と Jackson の R8 影響を避ける keep ルールを追加しました。
- 生成失敗時も履歴が更新されるよう、履歴変更通知と保存失敗ログを追加しました。

## R8 / GenAI 対応

- `com.google.genai.*` の SDK コアクラス、`com.google.genai.types.**`、`com.google.genai.errors.**`、`JsonSerializable` を保持します。
- `Signature` / annotation / inner class / enclosing method / method parameter 属性を保持します。
- Jackson `TypeReference` 本体と、その匿名サブクラスを保持します。
- release APK の DEX で、`Transformers$1..$4` が以下の generic signature を保持していることを確認しました。
  - `TypeReference<Tool>`
  - `TypeReference<Blob>`
  - `TypeReference<List<Content>>`
  - `TypeReference<List<UnifiedMetric>>`

## 確認内容

- ローカル signed release APK ビルド成功
  - `:app:clean :app:assembleRelease`
  - `versionName=0.3.3-typeref-signature-test`
  - `versionCode=30304`
- `apksigner verify --print-certs` 成功
  - 証明書: `CN=WondayWall Android Release, O=Studio Freesia, C=JP`
- release APK サイズ: 約 4.4 MB
- R8 mapping 確認
  - Google GenAI SDK 直下 78 クラスが 78 クラスとも保持対象
  - SDK コアクラス、`types`、`errors` の非 synthetic クラスは難読化されていない
  - `TypeReference` 本体は難読化されていない
- GitHub Actions 成功
  - Android #13: success
  - .NET Desktop #347: success
  - Android artifact: `WondayWall-Android-0.3.3-PullRequest136.72` (`4,325,319` bytes)

## 補足

実 API を使った画像生成は、端末への上書きインストール、API 呼び出し、壁紙変更の副作用があるため CI では実行していません。今回のエラー原因だった R8 の generic signature 欠落については、生成経路で使われる SDK クラスと APK 内 DEX の両方で確認済みです。