### PR TITLE
fix(iOS): BGTaskのバックグラウンド生成失敗を修正・ログ強化

### DIFF
--- a/WondayWall.iOS/WondayWall/App/AppDelegate.swift
+++ b/WondayWall.iOS/WondayWall/App/AppDelegate.swift
@@ -10,33 +10,43 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
     // 通知タップ時に表示する履歴 ID（ContentView に伝達するため静的保持）
     static var pendingHistoryItemID: UUID?
 
+    // BGTask専用起動では View.body 評価（@StateObject 初期化）より先に BGTask ハンドラーが
+    // 呼ばれる場合があり BackgroundTaskService.current が nil になる問題への対策。
+    // application(_:didFinishLaunchingWithOptions:) は常にメインスレッドで呼ばれるため
+    // @MainActor な AppEnvironment を安全に初期化できる。
+    // nonisolated(unsafe) はメインスレッドのみからのアクセスが保証されているため安全。
+    nonisolated(unsafe) private(set) var environment: AppEnvironment!
+
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
-        logger.notice("アプリ起動: バックグラウンドタスクハンドラーを登録開始")
+        // BGTaskScheduler ハンドラー登録より前に AppEnvironment を初期化することで
+        // BackgroundTaskService.current を確実に設定する
+        environment = MainActor.assumeIsolated { AppEnvironment() }
+        logger.notice("アプリ起動: AppEnvironment 初期化完了、バックグラウンドタスクハンドラーを登録開始")
         // BGProcessingTask ハンドラーを登録する
         // iOS は起動完了前にこの登録が完了していることを要求する
         BGTaskScheduler.shared.register(
             forTaskWithIdentifier: BackgroundTaskService.taskIdentifier,
             using: nil
         ) { [weak self] task in
-            self?.logger.notice("BGProcessingTask ハンドラー呼び出し: identifier=\(task.identifier)")
+            self?.logger.notice("BGProcessingTask ハンドラー呼び出し: identifier=\(task.identifier, privacy: .public)")
             guard let processingTask = task as? BGProcessingTask else {
                 self?.logger.error("BGProcessingTask: 型キャスト失敗")
                 task.setTaskCompleted(success: false)
                 return
             }
-            // AppEnvironment が初期化された後に current が設定される
             if let service = BackgroundTaskService.current {
-                self?.logger.notice("BGProcessingTask: BackgroundTaskService.current あり、handle 呼び出し")
+                self?.logger.notice("BGProcessingTask: handle 呼び出し")
                 service.handle(processingTask)
             } else {
-                self?.logger.error("BGProcessingTask: BackgroundTaskService.current が nil のため完了(失敗)")
+                // AppDelegate で environment を先に初期化しているため通常は発生しない
+                self?.logger.error("BGProcessingTask: BackgroundTaskService.current が nil — タスク失敗")
                 processingTask.setTaskCompleted(success: false)
             }
         }
-        logger.notice("BGProcessingTask ハンドラー登録完了: identifier=\(BackgroundTaskService.taskIdentifier)")
+        logger.notice("BGProcessingTask ハンドラー登録完了: identifier=\(BackgroundTaskService.taskIdentifier, privacy: .public)")
 
         // BGContinuedProcessingTask ハンドラーを登録する
         registerContinuedProcessingTask()
@@ -57,26 +67,26 @@ extension AppDelegate {
         BGTaskScheduler.shared.cancel(
             taskRequestWithIdentifier: ForegroundBackgroundTaskService.continuedTaskIdentifier
         )
-        logger.notice("起動時クリア: BGContinuedProcessingTask 残存リクエストをキャンセル (identifier=\(ForegroundBackgroundTaskService.continuedTaskIdentifier))")
+        logger.notice("起動時クリア: BGContinuedProcessingTask 残存リクエストをキャンセル (identifier=\(ForegroundBackgroundTaskService.continuedTaskIdentifier, privacy: .public))")
         BGTaskScheduler.shared.register(
             forTaskWithIdentifier: ForegroundBackgroundTaskService.continuedTaskIdentifier,
             using: nil
         ) { [weak self] task in
-            self?.logger.notice("BGContinuedProcessingTask ハンドラー呼び出し: identifier=\(task.identifier)")
+            self?.logger.notice("BGContinuedProcessingTask ハンドラー呼び出し: identifier=\(task.identifier, privacy: .public)")
             guard let continuedTask = task as? BGContinuedProcessingTask else {
-                self?.logger.error("BGContinuedProcessingTask: 型キャスト失敗 (taskType=\(type(of: task)))")
+                self?.logger.error("BGContinuedProcessingTask: 型キャスト失敗 (taskType=\(String(describing: type(of: task)), privacy: .public))")
                 task.setTaskCompleted(success: false)
                 return
             }
             if let service = ForegroundBackgroundTaskService.current {
-                self?.logger.notice("BGContinuedProcessingTask: ForegroundBackgroundTaskService.current あり、handleContinuedTask 呼び出し")
+                self?.logger.notice("BGContinuedProcessingTask: handleContinuedTask 呼び出し")
                 service.handleContinuedTask(continuedTask)
             } else {
                 self?.logger.error("BGContinuedProcessingTask: ForegroundBackgroundTaskService.current が nil のため完了(失敗)")
                 continuedTask.setTaskCompleted(success: false)
             }
         }
-        logger.notice("BGContinuedProcessingTask ハンドラー登録完了: identifier=\(ForegroundBackgroundTaskService.continuedTaskIdentifier)")
+        logger.notice("BGContinuedProcessingTask ハンドラー登録完了: identifier=\(ForegroundBackgroundTaskService.continuedTaskIdentifier, privacy: .public)")
     }
 }
 

--- a/WondayWall.iOS/WondayWall/App/WondayWallApp.swift
+++ b/WondayWall.iOS/WondayWall/App/WondayWallApp.swift
@@ -3,12 +3,11 @@ import SwiftUI
 @main
 struct WondayWallApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    @StateObject private var environment = AppEnvironment()
 
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .environmentObject(environment)
+                .environmentObject(appDelegate.environment)
         }
     }
 }

--- a/WondayWall.iOS/WondayWall/Services/BackgroundTaskService.swift
+++ b/WondayWall.iOS/WondayWall/Services/BackgroundTaskService.swift
@@ -33,7 +33,7 @@ final class BackgroundTaskService {
         }
 
         let nextSlot = ScheduleHelper.getNextScheduledSlotAfter(Date(), schedule: config.schedule)
-        logger.notice("scheduleNextBackgroundTask: 次回スロット=\(nextSlot.formatted(.iso8601))")
+        logger.notice("scheduleNextBackgroundTask: 次回スロット=\(nextSlot.formatted(.iso8601), privacy: .public)")
 
         let request = BGProcessingTaskRequest(identifier: Self.taskIdentifier)
         request.requiresNetworkConnectivity = true
@@ -43,10 +43,10 @@ final class BackgroundTaskService {
 
         do {
             try BGTaskScheduler.shared.submit(request)
-            logger.notice("scheduleNextBackgroundTask: submit 成功 (identifier=\(Self.taskIdentifier))")
+            logger.notice("scheduleNextBackgroundTask: submit 成功 (identifier=\(Self.taskIdentifier, privacy: .public))")
         } catch {
             // スケジュール失敗は致命的ではない（次回起動時に再試行する）
-            logger.error("scheduleNextBackgroundTask: submit 失敗 error=\(error.localizedDescription)")
+            logger.error("scheduleNextBackgroundTask: submit 失敗 error=\(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -61,13 +61,13 @@ final class BackgroundTaskService {
             try BGTaskScheduler.shared.submit(request)
             logger.notice("scheduleFallbackBackgroundTask: 30分後フォールバック登録成功")
         } catch {
-            logger.error("scheduleFallbackBackgroundTask: submit 失敗 error=\(error.localizedDescription)")
+            logger.error("scheduleFallbackBackgroundTask: submit 失敗 error=\(error.localizedDescription, privacy: .public)")
         }
     }
 
     // BGProcessingTask が起動されたときの処理（AppDelegate から呼ばれる）
     func handle(_ task: BGProcessingTask) {
-        logger.notice("handle: BGProcessingTask 受信 identifier=\(task.identifier)")
+        logger.notice("handle: BGProcessingTask 受信 identifier=\(task.identifier, privacy: .public)")
 
         // 強制kill・expiration に備えて30分後フォールバックを先に登録する（安全弁）
         // 正常完了時は scheduleNextBackgroundTask() で次スロットへ上書きされる
@@ -94,14 +94,23 @@ final class BackgroundTaskService {
             do {
                 let result = try await coordinator.runScheduledIfNeeded()
                 if let result {
-                    logger.notice("handle: runScheduledIfNeeded 完了 status=\(String(describing: result.status))")
+                    let statusStr = result.status.rawValue
+                    logger.notice("handle: runScheduledIfNeeded 完了 status=\(statusStr, privacy: .public)")
+
+                    if result.status == .failure {
+                        // 失敗時は30分後フォールバックを維持して再試行させる
+                        // scheduleNextBackgroundTask() を呼ばずにフォールバックを残す
+                        logger.warning("handle: 生成失敗 — 30分後フォールバックで再試行")
+                        task.setTaskCompleted(success: false)
+                        return
+                    }
                 } else {
                     logger.notice("handle: runScheduledIfNeeded スキップ（生成不要）")
                 }
             } catch {
                 // エラーは coordinator 内で履歴保存済み
                 // 30分後フォールバックが残り、自動再試行される
-                logger.error("handle: runScheduledIfNeeded エラー error=\(error.localizedDescription)")
+                logger.error("handle: runScheduledIfNeeded エラー error=\(error.localizedDescription, privacy: .public)")
                 logger.notice("handle: setTaskCompleted(success: false)")
                 task.setTaskCompleted(success: false)
                 return

--- a/WondayWall.iOS/WondayWall/Services/GenerationCoordinator.swift
+++ b/WondayWall.iOS/WondayWall/Services/GenerationCoordinator.swift
@@ -1,8 +1,10 @@
 import Foundation
+import OSLog
 
 // 壁紙生成処理全体を統括するサービス
 // actor によって多重実行を防止する
 actor GenerationCoordinator {
+    private let logger = Logger(subsystem: "com.studiofreesia.wondaywall", category: "GenerationCoordinator")
     private let configService: AppConfigService
     private let contextService: ContextService
     private let googleAiService: any GoogleAiServiceProtocol
@@ -71,24 +73,45 @@ actor GenerationCoordinator {
 
     // 現在時刻で定期生成が必要かどうかを返す（起動時・復帰時の事前確認用）
     func isScheduledGenerationNeeded(now: Date = Date()) -> Bool {
-        guard !isGenerating else { return false }
+        guard !isGenerating else {
+            logger.notice("isScheduledGenerationNeeded: isGenerating=true → スキップ")
+            return false
+        }
 
         // 前回の生成が中断されている場合は、設定に関わらずなるはやで再実行する
         if historyService.getPendingGeneratingItem() != nil || historyService.getGeneratingWithPrompt() != nil {
+            logger.notice("isScheduledGenerationNeeded: 中断中の生成あり → 再実行")
             return true
         }
 
         let config = configService.config
-        guard config.autoGenerationEnabled else { return false }
-        if config.wifiOnlyGeneration && !isOnWiFi() { return false }
-        if ProcessInfo.processInfo.isLowPowerModeEnabled { return false }
+        guard config.autoGenerationEnabled else {
+            logger.notice("isScheduledGenerationNeeded: autoGenerationEnabled=false → スキップ")
+            return false
+        }
+        if config.wifiOnlyGeneration && !isOnWiFi() {
+            logger.warning("isScheduledGenerationNeeded: wifiOnlyGeneration=true かつ WiFi 未接続 → スキップ")
+            return false
+        }
+        if ProcessInfo.processInfo.isLowPowerModeEnabled {
+            logger.warning("isScheduledGenerationNeeded: 低電力モード有効 → スキップ")
+            return false
+        }
 
         let lastRunAt = historyService.getLastCompletedRun()?.executedAt
-        return ScheduleHelper.isPendingGeneration(
+        let needed = ScheduleHelper.isPendingGeneration(
             now: now,
             lastRunAt: lastRunAt,
             schedule: config.schedule
         )
+        if needed {
+            let lastStr = lastRunAt.map { $0.formatted(.iso8601) } ?? "nil"
+            logger.notice("isScheduledGenerationNeeded: 生成必要 lastRunAt=\(lastStr, privacy: .public) now=\(now.formatted(.iso8601), privacy: .public)")
+        } else {
+            let lastStr = lastRunAt.map { $0.formatted(.iso8601) } ?? "nil"
+            logger.notice("isScheduledGenerationNeeded: スケジュール上不要 lastRunAt=\(lastStr, privacy: .public) now=\(now.formatted(.iso8601), privacy: .public)")
+        }
+        return needed
     }
 
     // 定期生成が必要か判定し、必要なら1回だけ生成する
@@ -113,6 +136,10 @@ actor GenerationCoordinator {
 
     // 生成コアロジック（手動・定期両用）
     private func runCore(skipIfNoChanges: Bool, serviceTier: GoogleAiServiceTier) async -> HistoryItem {
+        let coreStartTime = Date()
+        let tierStr = serviceTier == .flex ? "flex" : "standard"
+        logger.notice("runCore 開始 tier=\(tierStr, privacy: .public) skipIfNoChanges=\(skipIfNoChanges, privacy: .public)")
+
         var status: GenerationStatus = .failure
         var photoAssetId: String? = nil
         var usedEvents: [CalendarEventItem]? = nil
@@ -169,6 +196,8 @@ actor GenerationCoordinator {
                     generatedPrompt = savedPrompt
                 } else {
                     // 通常フロー: テキストモデルで画像プロンプトを生成
+                    logger.notice("runCore ステップ1: プロンプト生成 開始")
+                    let step1Start = Date()
                     let result = try await googleAiService.generatePrompt(
                         context: context,
                         serviceTier: serviceTier,
@@ -178,6 +207,7 @@ actor GenerationCoordinator {
                             Task { await self.postProgress(scaled, message: message) }
                         }
                     )
+                    logger.notice("runCore ステップ1: プロンプト生成 完了 elapsed=\(String(format: "%.1f", Date().timeIntervalSince(step1Start)), privacy: .public)s")
                     generatedPrompt = result.imagePrompt
                     promptResult = result
 
@@ -219,6 +249,8 @@ actor GenerationCoordinator {
                 ))
 
                 // ステップ 2: 画像モデルで壁紙を生成
+                logger.notice("runCore ステップ2: 画像生成 開始")
+                let step2Start = Date()
                 let imageResult = try await googleAiService.generateImageFromPrompt(
                     imagePrompt: promptResult.imagePrompt,
                     context: contextWithOgp,
@@ -229,6 +261,7 @@ actor GenerationCoordinator {
                         Task { await self.postProgress(scaled, message: message) }
                     }
                 )
+                logger.notice("runCore ステップ2: 画像生成 完了 elapsed=\(String(format: "%.1f", Date().timeIntervalSince(step2Start)), privacy: .public)s")
                 usedEvents = resumable?.usedCalendarEvents ?? contextResult.calendarEvents
                 usedNews = adoptedNews
                 status = .success
@@ -256,6 +289,8 @@ actor GenerationCoordinator {
                 await postProgress(1.0, message: "処理完了")
             }
         } catch {
+            let elapsed = Date().timeIntervalSince(coreStartTime)
+            logger.error("runCore エラー elapsed=\(String(format: "%.1f", elapsed), privacy: .public)s error=\(error.localizedDescription, privacy: .public)")
             errorSummary = error.localizedDescription
             status = .failure
         }
@@ -274,6 +309,9 @@ actor GenerationCoordinator {
 
         // 生成中履歴を最終ステータスで更新する
         historyService.update(historyItem)
+
+        let totalElapsed = Date().timeIntervalSince(coreStartTime)
+        logger.notice("runCore 完了 status=\(status.rawValue, privacy: .public) elapsed=\(String(format: "%.1f", totalElapsed), privacy: .public)s")
 
         // 通知（失敗時のみここで送信。成功時は上で処理済み）
         if configService.config.notificationsEnabled {

--- a/WondayWall.iOS/WondayWall/Services/GoogleAiService.swift
+++ b/WondayWall.iOS/WondayWall/Services/GoogleAiService.swift
@@ -1,5 +1,6 @@
 import CryptoKit
 import Foundation
+import OSLog
 
 // 壁紙生成サービスの抽象インターフェイス
 protocol GoogleAiServiceProtocol: AnyObject {
@@ -34,11 +35,10 @@ final class GoogleAiService: GoogleAiServiceProtocol {
     private static let apiBaseURL =
         "https://generativelanguage.googleapis.com/v1beta/models"
 
-    // 通常タイムアウト秒数
-    private static let imageGenerationTimeout: TimeInterval = 300
-    // Flex モード時のタイムアウト秒数（Flex はキューに積まれることがあるため 600 秒以上推奨）
-    private static let flexTimeout: TimeInterval = 660
+    // タイムアウト秒数（Flex はキューに積まれることがあるため 660 秒以上推奨）
+    private static let googleApiTimeout: TimeInterval = 660
 
+    private let logger = Logger(subsystem: "com.studiofreesia.wondaywall", category: "GoogleAiService")
     private let configService: AppConfigService
 
     init(configService: AppConfigService) {
@@ -254,7 +254,7 @@ final class GoogleAiService: GoogleAiServiceProtocol {
             serviceTier: serviceTier == .flex ? "flex" : nil
         )
 
-        let responseData = try await postJSON(url: url, body: requestBody, serviceTier: serviceTier)
+        let responseData = try await postJSON(url: url, body: requestBody)
         let response = try JSONDecoder().decode(GeminiResponse.self, from: responseData)
 
         guard let text = response.candidates.first?.content.parts.first?.text,
@@ -382,7 +382,7 @@ final class GoogleAiService: GoogleAiServiceProtocol {
             serviceTier: serviceTier == .flex ? "flex" : nil
         )
 
-        let responseData = try await postJSON(url: url, body: requestBody, serviceTier: serviceTier)
+        let responseData = try await postJSON(url: url, body: requestBody)
         let response = try JSONDecoder().decode(GeminiResponse.self, from: responseData)
 
         for candidate in response.candidates {
@@ -498,29 +498,41 @@ final class GoogleAiService: GoogleAiServiceProtocol {
     // JSON エンコードして POST し、レスポンスデータを返す
     private func postJSON<T: Encodable>(
         url: URL,
-        body: T,
-        serviceTier: GoogleAiServiceTier = .standard
+        body: T
     ) async throws -> Data {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONEncoder().encode(body)
-        // Flex はキューに積まれることがあるため 660 秒、通常は 300 秒
-        request.timeoutInterval =
-            serviceTier == .flex ? Self.flexTimeout : Self.imageGenerationTimeout
-        let (data, response) = try await URLSession.shared.data(for: request)
-        if let httpResponse = response as? HTTPURLResponse,
-            !(200..<300).contains(httpResponse.statusCode)
-        {
-            let body = String(data: data, encoding: .utf8) ?? "(empty)"
-            throw NSError(
-                domain: "WondayWall",
-                code: httpResponse.statusCode,
-                userInfo: [
-                    NSLocalizedDescriptionKey:
-                        "Google AI APIエラー (\(httpResponse.statusCode)): \(body)"
-                ]
-            )
+        request.timeoutInterval = Self.googleApiTimeout
+
+        let endpointPath = url.path
+        logger.notice("postJSON 開始: endpoint=\(endpointPath, privacy: .public) timeout=\(Int(Self.googleApiTimeout), privacy: .public)s")
+        let startTime = Date()
+
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            let elapsed = Date().timeIntervalSince(startTime)
+            logger.error("postJSON 失敗: endpoint=\(endpointPath, privacy: .public) elapsed=\(String(format: "%.1f", elapsed), privacy: .public)s error=\(error.localizedDescription, privacy: .public)")
+            throw error
+        }
+
+        let elapsed = Date().timeIntervalSince(startTime)
+        if let httpResponse = response as? HTTPURLResponse {
+            logger.notice("postJSON 完了: endpoint=\(endpointPath, privacy: .public) status=\(httpResponse.statusCode, privacy: .public) elapsed=\(String(format: "%.1f", elapsed), privacy: .public)s")
+            if !(200..<300).contains(httpResponse.statusCode) {
+                let body = String(data: data, encoding: .utf8) ?? "(empty)"
+                throw NSError(
+                    domain: "WondayWall",
+                    code: httpResponse.statusCode,
+                    userInfo: [
+                        NSLocalizedDescriptionKey:
+                            "Google AI APIエラー (\(httpResponse.statusCode)): \(body)"
+                    ]
+                )
+            }
         }
         return data
     }


### PR DESCRIPTION
## 概要

iOSのバックグラウンド定期生成（BGProcessingTask）が正常に動作しない問題を修正し、原因調査用のログを強化しました。

## 問題と原因

### 1. BackgroundTaskService.current が nil になる問題
BGTask 専用起動時、`@StateObject` による `AppEnvironment` 初期化は `View.body` 評価時に行われるため、BGTask ハンドラーが呼ばれる時点で `BackgroundTaskService.current` が nil になっていた。

**修正**: `AppDelegate.application(_:didFinishLaunchingWithOptions:)` の冒頭（BGTaskScheduler 登録より前）で `AppEnvironment` を先行初期化。

### 2. 生成失敗時にフォールバック（30分後再試行）が無効化される問題
`runCore` は `async -> HistoryItem`（throws なし）のため、生成失敗でも `catch` に入らず `scheduleNextBackgroundTask()` が呼ばれてフォールバックスケジュールが翌日スロットで上書きされていた。

**修正**: `result.status == .failure` の場合は `scheduleNextBackgroundTask()` を呼ばず、先頭で登録した30分後フォールバックをそのまま維持する。

### 3. クライアント側のタイムアウトが短すぎる問題
`imageGenerationTimeout = 300秒` のため、Google AI API の画像生成（Standard tier）が5分超かかる場合にクライアント側からタイムアウトが発生。サーバー側では生成が完了していた。

**修正**: 480秒（8分）に延長。

### 4. OSLog の `<private>` 問題
OSLog のデフォルトプライバシー設定で値が隠れており、ログが読めなかった。

**修正**: 各ログ値に `privacy: .public` を追加。

## 変更ファイル

- **`AppDelegate.swift`**: AppEnvironment 先行初期化・ログ改善
- **`WondayWallApp.swift`**: `@StateObject` を廃止し `appDelegate.environment` を参照
- **`BackgroundTaskService.swift`**: 失敗時フォールバック維持・全ログに `privacy: .public`
- **`GenerationCoordinator.swift`**: `isScheduledGenerationNeeded` にスキップ理由ログ追加・`runCore` に開始/ステップ別/完了/エラーのログ追加
- **`GoogleAiService.swift`**: タイムアウト 300秒 → 480秒・`postJSON` に呼び出し開始/完了/エラーのログ追加