### PR TITLE
fix(ios): iOSのニュースキャッシュと壁紙生成時のプロンプトマッピング問題を修正

### DIFF
--- a/WondayWall.iOS/WondayWall/Models/NewsTopicItem.swift
+++ b/WondayWall.iOS/WondayWall/Models/NewsTopicItem.swift
@@ -8,4 +8,23 @@ struct NewsTopicItem: Codable, Identifiable {
     let url: String?
     let publishedAt: Date
     let ogpImageUrl: String?
+    let sourceRssUrl: String?
+
+    init(
+        id: String,
+        title: String,
+        summary: String? = nil,
+        url: String? = nil,
+        publishedAt: Date,
+        ogpImageUrl: String? = nil,
+        sourceRssUrl: String? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.summary = summary
+        self.url = url
+        self.publishedAt = publishedAt
+        self.ogpImageUrl = ogpImageUrl
+        self.sourceRssUrl = sourceRssUrl
+    }
 }

--- a/WondayWall.iOS/WondayWall/Services/ContextService.swift
+++ b/WondayWall.iOS/WondayWall/Services/ContextService.swift
@@ -131,7 +131,8 @@ final class ContextService {
                 summary: item.summary,
                 url: item.url,
                 publishedAt: item.publishedAt,
-                ogpImageUrl: ogp
+                ogpImageUrl: ogp,
+                sourceRssUrl: item.sourceRssUrl
             )
         }
         // 結果をファイルにキャッシュする（RSSソース一覧も一緒に保存して変更検出に使う）
@@ -242,27 +243,24 @@ final class ContextService {
 
         // ニューストピックを取得して選別する
         onProgress?(0.18, "ニュースの取得中")
-        let weekAgo = Date().addingTimeInterval(-7 * 24 * 3600)
-        let rawRssItems = await withTaskGroup(of: [RssItem].self) { group in
-            for sourceUrl in configService.config.rssSources {
-                group.addTask { await self.fetchRssItems(from: sourceUrl, since: weekAgo) }
-            }
-            var all: [RssItem] = []
-            for await items in group { all.append(contentsOf: items) }
-            return all.sorted { $0.publishedAt > $1.publishedAt }
-        }
+        let cachedNews = await fetchNews()
         onProgress?(0.24, "ニュースの取得完了")
         let lastGenerated = historyService.getLastSuccessfulGenerated()
-        let selectedRssItems = selectPromptNewsItems(
-            recentNews: rawRssItems,
+        let selectedNewsItems = selectPromptNewsItems(
+            recentNews: cachedNews,
             lastGeneratedAt: lastGenerated?.executedAt
         )
         // 選別したアイテムの OGP 画像を並列取得する（最大10件）
+        // すでに OGP 画像があれば再取得はスキップする
         onProgress?(0.30, "OGP画像の取得中")
         let ogpURLs = await withTaskGroup(of: (String, String?).self) { group in
-            for item in selectedRssItems.prefix(10) {
+            for item in selectedNewsItems.prefix(10) {
                 if let url = item.url {
-                    group.addTask { (url, await self.fetchOGPImageURL(from: url)) }
+                    if let existingOgp = item.ogpImageUrl {
+                        group.addTask { (url, existingOgp) }
+                    } else {
+                        group.addTask { (url, await self.fetchOGPImageURL(from: url)) }
+                    }
                 }
             }
             var map: [String: String] = [:]
@@ -272,7 +270,7 @@ final class ContextService {
             return map
         }
         onProgress?(0.35, "コンテキスト生成完了")
-        let news: [NewsTopicItem] = selectedRssItems.map { item in
+        let news: [NewsTopicItem] = selectedNewsItems.map { item in
             let ogp = item.url.flatMap { ogpURLs[$0] }
             return NewsTopicItem(
                 id: item.url ?? item.title,
@@ -280,7 +278,8 @@ final class ContextService {
                 summary: item.summary,
                 url: item.url,
                 publishedAt: item.publishedAt,
-                ogpImageUrl: ogp
+                ogpImageUrl: ogp,
+                sourceRssUrl: item.sourceRssUrl
             )
         }
 
@@ -327,16 +326,16 @@ final class ContextService {
 
     // プロンプト用ニュースを選別する（最大10件）
     private func selectPromptNewsItems(
-        recentNews: [RssItem],
+        recentNews: [NewsTopicItem],
         lastGeneratedAt: Date?
-    ) -> [RssItem] {
+    ) -> [NewsTopicItem] {
         let maxCount = 10
         let maxRecentSinceLastGeneration = 3
-        var selected: [RssItem] = []
+        var selected: [NewsTopicItem] = []
         var selectedKeys = Set<String>()
 
         @discardableResult
-        func tryAdd(_ item: RssItem) -> Bool {
+        func tryAdd(_ item: NewsTopicItem) -> Bool {
             let key = item.url ?? item.title
             guard selected.count < maxCount, selectedKeys.insert(key).inserted else {
                 return false
@@ -361,8 +360,10 @@ final class ContextService {
 
         // 各 RSS ソースから先頭1件を追加（ソース間の多様性確保）
         var seenSources = Set<String>()
-        for item in recentNews where seenSources.insert(item.sourceRssUrl).inserted {
-            tryAdd(item)
+        for item in recentNews {
+            if let sourceUrl = item.sourceRssUrl, seenSources.insert(sourceUrl).inserted {
+                tryAdd(item)
+            }
         }
 
         // 残り全件を追加

--- a/WondayWall.iOS/WondayWall/Services/GenerationCoordinator.swift
+++ b/WondayWall.iOS/WondayWall/Services/GenerationCoordinator.swift
@@ -191,7 +191,12 @@ actor GenerationCoordinator {
                 let promptResult: PromptGenerationResult
                 if let savedPrompt = resumable?.generatedPrompt {
                     // 再開フロー: 保存済みプロンプトと採用ニュース ID を再利用（中間保存① はスキップ）
-                    let selectedIds = resumable?.usedNewsTopics?.map { $0.id } ?? []
+                    let selectedIds = resumable?.usedNewsTopics?.compactMap { usedItem -> String? in
+                        if let index = contextResult.newsTopics.firstIndex(where: { $0.id == usedItem.id }) {
+                            return "news-\(index + 1)"
+                        }
+                        return nil
+                    } ?? []
                     promptResult = PromptGenerationResult(imagePrompt: savedPrompt, selectedNewsIds: selectedIds)
                     generatedPrompt = savedPrompt
                 } else {
@@ -212,8 +217,14 @@ actor GenerationCoordinator {
                     promptResult = result
 
                     // 中間保存①: generatingPromptReady（プロンプト生成完了・画像 API 呼び出し前）
-                    let adoptedNewsForPrompt = contextResult.newsTopics.filter {
-                        result.selectedNewsIds.contains($0.id)
+                    let adoptedNewsForPrompt = result.selectedNewsIds.compactMap { id -> NewsTopicItem? in
+                        guard id.hasPrefix("news-"),
+                              let indexStr = id.split(separator: "-").last,
+                              let index = Int(indexStr),
+                              index >= 1 && index <= contextResult.newsTopics.count else {
+                            return nil
+                        }
+                        return contextResult.newsTopics[index - 1]
                     }
                     historyService.update(HistoryItem(
                         id: generatingItem.id,
@@ -227,8 +238,20 @@ actor GenerationCoordinator {
                 }
 
                 // 採用ニュースを決定（再開: resumable.usedNewsTopics / 新規: selectedNewsIds でフィルタ）
-                let adoptedNews = resumable?.usedNewsTopics
-                    ?? contextResult.newsTopics.filter { promptResult.selectedNewsIds.contains($0.id) }
+                let adoptedNews: [NewsTopicItem]
+                if let resumableNews = resumable?.usedNewsTopics {
+                    adoptedNews = resumableNews
+                } else {
+                    adoptedNews = promptResult.selectedNewsIds.compactMap { id -> NewsTopicItem? in
+                        guard id.hasPrefix("news-"),
+                              let indexStr = id.split(separator: "-").last,
+                              let index = Int(indexStr),
+                              index >= 1 && index <= contextResult.newsTopics.count else {
+                            return nil
+                        }
+                        return contextResult.newsTopics[index - 1]
+                    }
+                }
 
                 // ステップ 1.5: 採用ニュースの OGP 画像をダウンロードする
                 let contextWithOgp = await googleAiService.fetchOgpImages(


### PR DESCRIPTION
### 概要
iOS版の壁紙生成処理において、ニュースデータがプロンプトに正しく反映されないバグ、およびキャッシュ制御が期待通りに機能していなかった問題を修正しました。

### 変更点
1. **NewsTopicItem.swift**
   - RSSソース元の特定とキャッシュ・判定のために `sourceRssUrl` フィールドを追加。
2. **ContextService.swift**
   - コンテキスト構築 (`buildContext`) 時に、直接RSSフィードを取得するのではなく、1時間のTTLを持つ既存のキャッシュ機構 (`fetchNews`) を経由するように変更。
   - ニュース情報やOGP取得ロジックで利用していた `RssItem` を、`NewsTopicItem` ベースに変更。
3. **GenerationCoordinator.swift**
   - Gemini から返却される選択結果のIDである `"news-X"` と、内部データモデルのIDとの不一致をマッピング・変換処理で修正。
   - レジューム処理（途中再開フロー）においてもID変換の不整合を解消。

### テスト結果
- `xcodebuild` を用いたビルドが正常に成功することを確認済みです。