### PR TITLE
[codex] iOS履歴に写真風ビューアを追加

### DIFF
--- a/WondayWall.iOS/WondayWall/Views/History/HistoryDetailView.swift
+++ b/WondayWall.iOS/WondayWall/Views/History/HistoryDetailView.swift
@@ -3,25 +3,11 @@ import SwiftUI
 // 履歴詳細画面 — 画像プレビュー・使用データ・アクション
 struct HistoryDetailView: View {
     let item: HistoryItem
-    let showsImagePreview: Bool
-    @EnvironmentObject private var environment: AppEnvironment
-    // Photos から非同期読み込まれた画像
-    @State private var loadedImage: UIImage?
     @Environment(\.openURL) private var openURL
-
-    init(item: HistoryItem, showsImagePreview: Bool = true) {
-        self.item = item
-        self.showsImagePreview = showsImagePreview
-    }
 
     var body: some View {
         ScrollView {
             VStack(spacing: 20) {
-                // 画像プレビュー
-                if showsImagePreview && item.isSuccess {
-                    imagePreview
-                }
-
                 // ステータスバッジ
                 statusBadge
 
@@ -49,31 +35,6 @@ struct HistoryDetailView: View {
         }
         .navigationTitle(item.executedAt.formatted(date: .abbreviated, time: .omitted))
         .navigationBarTitleDisplayMode(.inline)
-        .onAppear {
-            guard showsImagePreview else { return }
-            Task<Void, Never> { @MainActor in await self.loadImage() }
-        }
-    }
-
-    // 画像プレビュー
-    @ViewBuilder
-    private var imagePreview: some View {
-        if let image = loadedImage {
-            Image(uiImage: image)
-                .resizable()
-                .scaledToFit()
-                .cornerRadius(16)
-                .shadow(radius: 8)
-        } else {
-            ZStack {
-                RoundedRectangle(cornerRadius: 16)
-                    .fill(Color(.systemGray5))
-                    .aspectRatio(9.0 / 19.5, contentMode: .fit)
-                Image(systemName: "photo.slash")
-                    .font(.system(size: 48))
-                    .foregroundStyle(.secondary)
-            }
-        }
     }
 
     // ステータスバッジ
@@ -201,16 +162,11 @@ struct HistoryDetailView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private var statusIcon: String {        if item.isSkipped { return "minus.circle" }
+    private var statusIcon: String {
+        if item.isSkipped { return "minus.circle" }
         if item.isGenerating { return "hourglass.circle" }
         if item.isSuccess { return "checkmark.circle.fill" }
         return "xmark.circle.fill"
-    }
-
-    // Photos から画像を非同期読み込む
-    private func loadImage() async {
-        guard item.isSuccess, let assetId = item.photoAssetId else { return }
-        loadedImage = await environment.wallpaperService.loadImage(assetId: assetId)
     }
 
     private var statusColor: Color {

--- a/WondayWall.iOS/WondayWall/Views/History/HistoryDetailView.swift
+++ b/WondayWall.iOS/WondayWall/Views/History/HistoryDetailView.swift
@@ -3,16 +3,22 @@ import SwiftUI
 // 履歴詳細画面 — 画像プレビュー・使用データ・アクション
 struct HistoryDetailView: View {
     let item: HistoryItem
+    let showsImagePreview: Bool
     @EnvironmentObject private var environment: AppEnvironment
     // Photos から非同期読み込まれた画像
     @State private var loadedImage: UIImage?
     @Environment(\.openURL) private var openURL
 
+    init(item: HistoryItem, showsImagePreview: Bool = true) {
+        self.item = item
+        self.showsImagePreview = showsImagePreview
+    }
+
     var body: some View {
         ScrollView {
             VStack(spacing: 20) {
                 // 画像プレビュー
-                if item.isSuccess {
+                if showsImagePreview && item.isSuccess {
                     imagePreview
                 }
 
@@ -44,6 +50,7 @@ struct HistoryDetailView: View {
         .navigationTitle(item.executedAt.formatted(date: .abbreviated, time: .omitted))
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
+            guard showsImagePreview else { return }
             Task<Void, Never> { @MainActor in await self.loadImage() }
         }
     }

--- a/WondayWall.iOS/WondayWall/Views/History/HistoryPhotoPagerView.swift
+++ b/WondayWall.iOS/WondayWall/Views/History/HistoryPhotoPagerView.swift
@@ -27,7 +27,6 @@ struct HistoryPhotoPagerView: View {
                 }
             }
             .tabViewStyle(.page(indexDisplayMode: .never))
-            .ignoresSafeArea()
         }
         .navigationTitle(currentTitle)
         .navigationBarTitleDisplayMode(.inline)
@@ -36,7 +35,7 @@ struct HistoryPhotoPagerView: View {
         .toolbarBackground(.visible, for: .navigationBar)
         .sheet(item: $detailItem) { item in
             NavigationStack {
-                HistoryDetailView(item: item, showsImagePreview: false)
+                HistoryDetailView(item: item)
                     .environmentObject(environment)
             }
             .presentationDetents([.medium, .large])
@@ -64,7 +63,6 @@ private struct HistoryPhotoPageView: View {
     var body: some View {
         ZStack {
             Color.black
-                .ignoresSafeArea()
 
             if let image {
                 GeometryReader { geometry in
@@ -74,7 +72,6 @@ private struct HistoryPhotoPageView: View {
                         .frame(width: geometry.size.width, height: geometry.size.height)
                         .clipped()
                 }
-                .ignoresSafeArea()
             } else if item.isSuccess && !didFinishLoading {
                 ProgressView()
                     .tint(.white)

--- a/WondayWall.iOS/WondayWall/Views/History/HistoryPhotoPagerView.swift
+++ b/WondayWall.iOS/WondayWall/Views/History/HistoryPhotoPagerView.swift
@@ -14,10 +14,7 @@ struct HistoryPhotoPagerView: View {
     }
 
     var body: some View {
-        ZStack {
-            Color.black
-                .ignoresSafeArea()
-
+        ZStack(alignment: .top) {
             TabView(selection: $selectedItemID) {
                 ForEach(items) { item in
                     HistoryPhotoPageView(item: item) {
@@ -27,12 +24,19 @@ struct HistoryPhotoPagerView: View {
                 }
             }
             .tabViewStyle(.page(indexDisplayMode: .never))
+            .ignoresSafeArea(edges: .top)
         }
-        .navigationTitle(currentTitle)
+        .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarColorScheme(.dark, for: .navigationBar)
-        .toolbarBackground(.black, for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                if let currentItem {
+                    HistoryPhotoHeaderView(item: currentItem) {
+                        detailItem = currentItem
+                    }
+                }
+            }
+        }
         .sheet(item: $detailItem) { item in
             NavigationStack {
                 HistoryDetailView(item: item)
@@ -43,11 +47,48 @@ struct HistoryPhotoPagerView: View {
         }
     }
 
-    private var currentTitle: String {
-        guard let item = items.first(where: { $0.id == selectedItemID }) else {
-            return "履歴"
+    private var currentItem: HistoryItem? {
+        items.first { $0.id == selectedItemID }
+    }
+}
+
+// 標準ナビゲーションバー上に表示する Liquid Glass 風タイトル
+private struct HistoryPhotoHeaderView: View {
+    let item: HistoryItem
+    let onShowDetail: () -> Void
+
+    private static let relativeDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        formatter.doesRelativeDateFormatting = true
+        return formatter
+    }()
+
+    var body: some View {
+        GlassEffectContainer(spacing: 10) {
+            titleButton
         }
-        return item.executedAt.formatted(date: .abbreviated, time: .omitted)
+    }
+
+    private var titleButton: some View {
+        Button(action: onShowDetail) {
+            VStack(alignment: .center, spacing: 2) {
+                Text(Self.relativeDateFormatter.string(from: item.executedAt))
+                    .font(.headline)
+                    .lineLimit(1)
+                Text(item.executedAt.formatted(date: .omitted, time: .shortened))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 4)
+        }
+        .frame(minWidth: 160, maxWidth: .infinity)
+        .buttonStyle(.plain)
+        .glassEffect(.regular.interactive(), in: Capsule())
+        .accessibilityLabel("履歴詳細を表示")
     }
 }
 
@@ -62,8 +103,6 @@ private struct HistoryPhotoPageView: View {
 
     var body: some View {
         ZStack {
-            Color.black
-
             if let image {
                 GeometryReader { geometry in
                     Image(uiImage: image)
@@ -74,7 +113,6 @@ private struct HistoryPhotoPageView: View {
                 }
             } else if item.isSuccess && !didFinishLoading {
                 ProgressView()
-                    .tint(.white)
             } else {
                 placeholder
             }
@@ -106,11 +144,9 @@ private struct HistoryPhotoPageView: View {
                 Text(statusLabel)
                     .font(.title3)
                     .fontWeight(.semibold)
-                    .foregroundStyle(.white)
                 Text(item.executedAt.formatted(date: .abbreviated, time: .shortened))
                     .font(.subheadline)
-                    .foregroundStyle(.white.opacity(0.68))
-            }
+                }
         }
         .padding(28)
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/WondayWall.iOS/WondayWall/Views/History/HistoryPhotoPagerView.swift
+++ b/WondayWall.iOS/WondayWall/Views/History/HistoryPhotoPagerView.swift
@@ -1,0 +1,151 @@
+import SwiftUI
+
+// 履歴を写真アプリ風に左右スワイプで切り替えるビュー
+struct HistoryPhotoPagerView: View {
+    let items: [HistoryItem]
+
+    @EnvironmentObject private var environment: AppEnvironment
+    @State private var selectedItemID: UUID
+    @State private var detailItem: HistoryItem?
+
+    init(items: [HistoryItem], initialItemID: UUID) {
+        self.items = items
+        _selectedItemID = State(initialValue: initialItemID)
+    }
+
+    var body: some View {
+        ZStack {
+            Color.black
+                .ignoresSafeArea()
+
+            TabView(selection: $selectedItemID) {
+                ForEach(items) { item in
+                    HistoryPhotoPageView(item: item) {
+                        detailItem = item
+                    }
+                    .tag(item.id)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .never))
+        }
+        .navigationTitle(currentTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .toolbarBackground(.black, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+        .sheet(item: $detailItem) { item in
+            NavigationStack {
+                HistoryDetailView(item: item)
+                    .environmentObject(environment)
+            }
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.visible)
+        }
+    }
+
+    private var currentTitle: String {
+        guard let item = items.first(where: { $0.id == selectedItemID }) else {
+            return "履歴"
+        }
+        return item.executedAt.formatted(date: .abbreviated, time: .omitted)
+    }
+}
+
+// 1件分の履歴画像またはプレースホルダーを表示する
+private struct HistoryPhotoPageView: View {
+    let item: HistoryItem
+    let onShowDetail: () -> Void
+
+    @EnvironmentObject private var environment: AppEnvironment
+    @State private var image: UIImage?
+    @State private var didFinishLoading = false
+
+    var body: some View {
+        ZStack {
+            Color.black
+                .ignoresSafeArea()
+
+            if let image {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if item.isSuccess && !didFinishLoading {
+                ProgressView()
+                    .tint(.white)
+            } else {
+                placeholder
+            }
+        }
+        .contentShape(Rectangle())
+        .simultaneousGesture(detailSwipeGesture)
+        .task(id: item.id) {
+            await loadImage()
+        }
+    }
+
+    private var detailSwipeGesture: some Gesture {
+        DragGesture(minimumDistance: 24)
+            .onEnded { value in
+                let width = abs(value.translation.width)
+                let height = abs(value.translation.height)
+                guard value.translation.height < -72, height > width * 1.4 else { return }
+                onShowDetail()
+            }
+    }
+
+    private var placeholder: some View {
+        VStack(spacing: 16) {
+            Image(systemName: statusIcon)
+                .font(.system(size: 54, weight: .semibold))
+                .foregroundStyle(statusColor)
+
+            VStack(spacing: 6) {
+                Text(statusLabel)
+                    .font(.title3)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.white)
+                Text(item.executedAt.formatted(date: .abbreviated, time: .shortened))
+                    .font(.subheadline)
+                    .foregroundStyle(.white.opacity(0.68))
+            }
+        }
+        .padding(28)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @MainActor
+    private func loadImage() async {
+        image = nil
+        didFinishLoading = false
+
+        guard item.isSuccess, let assetId = item.photoAssetId else {
+            didFinishLoading = true
+            return
+        }
+
+        image = await environment.wallpaperService.loadImage(assetId: assetId)
+        didFinishLoading = true
+    }
+
+    private var statusIcon: String {
+        if item.isSkipped { return "minus.circle" }
+        if item.isGenerating { return "hourglass.circle" }
+        if item.isSuccess { return "photo.slash" }
+        return "xmark.circle.fill"
+    }
+
+    private var statusColor: Color {
+        if item.isSkipped { return .gray }
+        if item.isGenerating { return .orange }
+        if item.isSuccess { return .white.opacity(0.72) }
+        return .red
+    }
+
+    private var statusLabel: String {
+        if item.isSkipped { return "スキップ" }
+        if item.isGenerating { return "生成中" }
+        if item.isSuccess { return "画像を読み込めません" }
+        return "失敗"
+    }
+}

--- a/WondayWall.iOS/WondayWall/Views/History/HistoryPhotoPagerView.swift
+++ b/WondayWall.iOS/WondayWall/Views/History/HistoryPhotoPagerView.swift
@@ -4,9 +4,8 @@ import SwiftUI
 struct HistoryPhotoPagerView: View {
     let items: [HistoryItem]
 
-    @EnvironmentObject private var environment: AppEnvironment
     @State private var selectedItemID: UUID
-    @State private var detailItem: HistoryItem?
+    @State private var detailPresentation: HistoryDetailPresentation?
 
     init(items: [HistoryItem], initialItemID: UUID) {
         self.items = items
@@ -14,33 +13,28 @@ struct HistoryPhotoPagerView: View {
     }
 
     var body: some View {
-        ZStack(alignment: .top) {
-            TabView(selection: $selectedItemID) {
-                ForEach(items) { item in
-                    HistoryPhotoPageView(item: item) {
-                        detailItem = item
-                    }
+        TabView(selection: $selectedItemID) {
+            ForEach(items) { item in
+                HistoryPhotoPageView(item: item)
                     .tag(item.id)
-                }
             }
-            .tabViewStyle(.page(indexDisplayMode: .never))
-            .ignoresSafeArea(edges: .top)
         }
+        .tabViewStyle(.page(indexDisplayMode: .never))
+        .ignoresSafeArea(edges: .top)
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .principal) {
                 if let currentItem {
                     HistoryPhotoHeaderView(item: currentItem) {
-                        detailItem = currentItem
+                        showDetail(currentItem)
                     }
                 }
             }
         }
-        .sheet(item: $detailItem) { item in
+        .sheet(item: $detailPresentation) { presentation in
             NavigationStack {
-                HistoryDetailView(item: item)
-                    .environmentObject(environment)
+                HistoryDetailView(item: presentation.item)
             }
             .presentationDetents([.medium, .large])
             .presentationDragIndicator(.visible)
@@ -50,6 +44,15 @@ struct HistoryPhotoPagerView: View {
     private var currentItem: HistoryItem? {
         items.first { $0.id == selectedItemID }
     }
+
+    private func showDetail(_ item: HistoryItem) {
+        detailPresentation = HistoryDetailPresentation(item: item)
+    }
+}
+
+private struct HistoryDetailPresentation: Identifiable {
+    let id = UUID()
+    let item: HistoryItem
 }
 
 // 標準ナビゲーションバー上に表示する Liquid Glass 風タイトル
@@ -84,8 +87,9 @@ private struct HistoryPhotoHeaderView: View {
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 4)
+            .frame(minWidth: 160)
+            .contentShape(Capsule())
         }
-        .frame(minWidth: 160, maxWidth: .infinity)
         .buttonStyle(.plain)
         .glassEffect(.regular.interactive(), in: Capsule())
         .accessibilityLabel("履歴詳細を表示")
@@ -95,7 +99,6 @@ private struct HistoryPhotoHeaderView: View {
 // 1件分の履歴画像またはプレースホルダーを表示する
 private struct HistoryPhotoPageView: View {
     let item: HistoryItem
-    let onShowDetail: () -> Void
 
     @EnvironmentObject private var environment: AppEnvironment
     @State private var image: UIImage?
@@ -117,21 +120,9 @@ private struct HistoryPhotoPageView: View {
                 placeholder
             }
         }
-        .contentShape(Rectangle())
-        .simultaneousGesture(detailSwipeGesture)
         .task(id: item.id) {
             await loadImage()
         }
-    }
-
-    private var detailSwipeGesture: some Gesture {
-        DragGesture(minimumDistance: 24)
-            .onEnded { value in
-                let width = abs(value.translation.width)
-                let height = abs(value.translation.height)
-                guard value.translation.height < -72, height > width * 1.4 else { return }
-                onShowDetail()
-            }
     }
 
     private var placeholder: some View {
@@ -146,7 +137,7 @@ private struct HistoryPhotoPageView: View {
                     .fontWeight(.semibold)
                 Text(item.executedAt.formatted(date: .abbreviated, time: .shortened))
                     .font(.subheadline)
-                }
+            }
         }
         .padding(28)
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/WondayWall.iOS/WondayWall/Views/History/HistoryPhotoPagerView.swift
+++ b/WondayWall.iOS/WondayWall/Views/History/HistoryPhotoPagerView.swift
@@ -27,6 +27,7 @@ struct HistoryPhotoPagerView: View {
                 }
             }
             .tabViewStyle(.page(indexDisplayMode: .never))
+            .ignoresSafeArea()
         }
         .navigationTitle(currentTitle)
         .navigationBarTitleDisplayMode(.inline)
@@ -35,7 +36,7 @@ struct HistoryPhotoPagerView: View {
         .toolbarBackground(.visible, for: .navigationBar)
         .sheet(item: $detailItem) { item in
             NavigationStack {
-                HistoryDetailView(item: item)
+                HistoryDetailView(item: item, showsImagePreview: false)
                     .environmentObject(environment)
             }
             .presentationDetents([.medium, .large])
@@ -66,10 +67,14 @@ private struct HistoryPhotoPageView: View {
                 .ignoresSafeArea()
 
             if let image {
-                Image(uiImage: image)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                GeometryReader { geometry in
+                    Image(uiImage: image)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: geometry.size.width, height: geometry.size.height)
+                        .clipped()
+                }
+                .ignoresSafeArea()
             } else if item.isSuccess && !didFinishLoading {
                 ProgressView()
                     .tint(.white)

--- a/WondayWall.iOS/WondayWall/Views/History/HistoryView.swift
+++ b/WondayWall.iOS/WondayWall/Views/History/HistoryView.swift
@@ -43,7 +43,7 @@ private struct HistoryContentView: View {
                 List {
                     ForEach(vm.items) { item in
                         NavigationLink {
-                            HistoryDetailView(item: item)
+                            HistoryPhotoPagerView(items: vm.items, initialItemID: item.id)
                                 .environmentObject(environment)
                         } label: {
                             historyRow(item)


### PR DESCRIPTION
## 概要
- iOS の履歴一覧から全履歴を写真アプリ風の横スワイプビューアで開くように変更
- 成功履歴は Photos 画像を表示し、失敗・スキップ・生成中・画像読込失敗はステータス付きプレースホルダーを表示
- 上スワイプで現在表示中の履歴詳細を標準 sheet として開くように追加

## 確認
- XcodeBuildMCP `build_sim`（WondayWall / Debug / iPhone 17 Pro Simulator）成功

Closes #139