### PR TITLE
[codex] AndroidウィザードのRSS入力を次へで確認する

### DIFF
--- a/WondayWall.Android/app/src/main/kotlin/com/studiofreesia/wondaywall/ui/screens/wizard/WizardScreen.kt
+++ b/WondayWall.Android/app/src/main/kotlin/com/studiofreesia/wondaywall/ui/screens/wizard/WizardScreen.kt
@@ -4,6 +4,8 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
+import android.view.Gravity
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
@@ -29,11 +31,9 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Key
@@ -51,7 +51,6 @@ import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -83,7 +82,6 @@ import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import com.studiofreesia.wondaywall.models.UpdateSchedule
 import com.studiofreesia.wondaywall.services.NotificationPermissionHelper
-import com.studiofreesia.wondaywall.ui.components.FaviconIcon
 import com.studiofreesia.wondaywall.ui.components.SquareAppIcon
 import com.studiofreesia.wondaywall.ui.util.canDisplayImageReference
 import com.studiofreesia.wondaywall.ui.util.imageReferenceModel
@@ -103,7 +101,8 @@ fun WizardScreen(
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
-    val canGoNext = uiState.currentStep != 1 || uiState.apiKey.isNotBlank()
+    val canGoNext = (uiState.currentStep != 1 || uiState.apiKey.isNotBlank()) &&
+        !uiState.isResolvingRssSource
     var pendingStorageAction by remember { mutableStateOf<PendingStorageGenerationAction?>(null) }
 
     fun runGenerationAction(action: PendingStorageGenerationAction) {
@@ -138,6 +137,16 @@ fun WizardScreen(
         uiState.errorMessage?.let {
             snackbarHostState.showSnackbar(it)
             viewModel.clearError()
+        }
+    }
+
+    LaunchedEffect(uiState.topToastMessage) {
+        uiState.topToastMessage?.let {
+            Toast.makeText(context, it, Toast.LENGTH_LONG).apply {
+                setGravity(Gravity.TOP or Gravity.CENTER_HORIZONTAL, 0, 96)
+                show()
+            }
+            viewModel.clearTopToastMessage()
         }
     }
 
@@ -196,7 +205,10 @@ fun WizardScreen(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 if (uiState.currentStep > 0) {
-                    OutlinedButton(onClick = { viewModel.prevStep() }) {
+                    OutlinedButton(
+                        onClick = { viewModel.prevStep() },
+                        enabled = !uiState.isResolvingRssSource,
+                    ) {
                         Icon(Icons.Default.ArrowBack, contentDescription = null)
                         Text("  戻る")
                     }
@@ -215,8 +227,13 @@ fun WizardScreen(
                         onClick = { viewModel.nextStep() },
                         enabled = canGoNext,
                     ) {
-                        Text("次へ  ")
-                        Icon(Icons.Default.ArrowForward, contentDescription = null)
+                        if (uiState.currentStep == 3 && uiState.isResolvingRssSource) {
+                            CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+                            Text("  確認中…")
+                        } else {
+                            Text("次へ  ")
+                            Icon(Icons.Default.ArrowForward, contentDescription = null)
+                        }
                     }
                 } else {
                     Button(
@@ -426,8 +443,6 @@ private fun StepCalendar(uiState: WizardUiState, viewModel: WizardViewModel) {
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun StepPromptAndRss(uiState: WizardUiState, viewModel: WizardViewModel) {
-    var newRssUrl by remember { mutableStateOf("") }
-
     // プロンプトテンプレート一覧
     val promptTemplates = listOf(
         "水彩画風で生成してください",
@@ -484,50 +499,20 @@ private fun StepPromptAndRss(uiState: WizardUiState, viewModel: WizardViewModel)
         // RSS ソース
         Text("RSS ニュースソース", style = MaterialTheme.typography.titleMedium)
         Text(
-            text = "ニュースを参考にした壁紙を生成したい場合はニュースサイト URL を追加してください。RSS URL の直接入力もできます。",
+            text = "ニュースを参考にした壁紙を生成したい場合はニュースサイト URL を入力してください。RSS URL の直接入力もできます。",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
 
-        Row(
+        OutlinedTextField(
+            value = uiState.rssSourceUrl,
+            onValueChange = { viewModel.updateRssSourceUrl(it) },
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            OutlinedTextField(
-                value = newRssUrl,
-                onValueChange = { newRssUrl = it },
-                modifier = Modifier.weight(1f),
-                placeholder = { Text("ニュースサイト URL") },
-                singleLine = true,
-            )
-            IconButton(onClick = {
-                viewModel.addRssSource(newRssUrl) {
-                    newRssUrl = ""
-                }
-            }) {
-                Icon(Icons.Default.Add, contentDescription = "追加")
-            }
-        }
-
-        uiState.rssSources.forEach { url ->
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                FaviconIcon(url = url, size = 24.dp)
-                Text(
-                    text = url,
-                    modifier = Modifier.weight(1f),
-                    style = MaterialTheme.typography.bodySmall,
-                    maxLines = 1,
-                )
-                IconButton(onClick = { viewModel.removeRssSource(url) }) {
-                    Icon(Icons.Default.Close, contentDescription = "削除")
-                }
-            }
-        }
+            placeholder = { Text("https://example.com") },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+            singleLine = true,
+            enabled = !uiState.isResolvingRssSource,
+        )
     }
 }
 

--- a/WondayWall.Android/app/src/main/kotlin/com/studiofreesia/wondaywall/ui/screens/wizard/WizardViewModel.kt
+++ b/WondayWall.Android/app/src/main/kotlin/com/studiofreesia/wondaywall/ui/screens/wizard/WizardViewModel.kt
@@ -27,17 +27,20 @@ data class WizardUiState(
     val hasCalendarPermission: Boolean = false,
     val calendarSources: List<CalendarSourceItem> = emptyList(),
     val selectedCalendarIds: Set<String> = emptySet(),
-    val rssSources: List<String> = emptyList(),
+    val rssSourceUrl: String = "",
+    val resolvedRssSourceUrl: String? = null,
     val userPrompt: String = "",
     val schedule: UpdateSchedule = UpdateSchedule.OnceADay,
     val wifiOnly: Boolean = false,
     val skipOnBatterySaver: Boolean = true,
     val showNotification: Boolean = true,
     val updateLockScreen: Boolean = false,
+    val isResolvingRssSource: Boolean = false,
     val isTestGenerating: Boolean = false,
     val isCompleting: Boolean = false,
     val generationProgress: GenerationProgress? = null,
     val testGenerationImageReference: String? = null,
+    val topToastMessage: String? = null,
     val errorMessage: String? = null,
 )
 
@@ -70,6 +73,7 @@ class WizardViewModel(
 
     // 次のステップに進む
     fun nextStep() {
+        if (_uiState.value.isResolvingRssSource) return
         val current = _uiState.value.currentStep
         if (current == 1 && _uiState.value.apiKey.isBlank()) {
             _uiState.value = _uiState.value.copy(
@@ -77,6 +81,15 @@ class WizardViewModel(
             )
             return
         }
+        if (current == 3) {
+            resolveRssSourceAndAdvance()
+            return
+        }
+        advanceToNextStep(current)
+    }
+
+    // 次のステップへ進める
+    private fun advanceToNextStep(current: Int) {
         if (current < WIZARD_TOTAL_STEPS - 1) {
             _uiState.value = _uiState.value.copy(currentStep = current + 1)
         }
@@ -142,32 +155,47 @@ class WizardViewModel(
         _uiState.value = _uiState.value.copy(selectedCalendarIds = updated)
     }
 
-    // RSS ソースを追加する
-    fun addRssSource(url: String, onAdded: () -> Unit = {}) {
-        if (url.isBlank()) return
+    // RSS ソース URL を更新する
+    fun updateRssSourceUrl(url: String) {
+        _uiState.value = _uiState.value.copy(
+            rssSourceUrl = url,
+            resolvedRssSourceUrl = null,
+        )
+    }
+
+    // RSS ソースを解決してから次のステップに進む
+    private fun resolveRssSourceAndAdvance() {
+        val state = _uiState.value
+        val sourceUrl = state.rssSourceUrl.trim()
+        if (sourceUrl.isBlank()) {
+            _uiState.value = state.copy(
+                rssSourceUrl = "",
+                resolvedRssSourceUrl = null,
+                currentStep = state.currentStep + 1,
+            )
+            return
+        }
+
         viewModelScope.launch {
-            val sourceUrl = url.trim()
+            _uiState.value = _uiState.value.copy(isResolvingRssSource = true)
             val resolvedRssUrl = contextService.resolveRssSourceUrl(sourceUrl)
             if (resolvedRssUrl == null) {
                 _uiState.value = _uiState.value.copy(
-                    errorMessage = "指定のサイトからニュース情報を得られませんでした。"
+                    isResolvingRssSource = false,
+                    resolvedRssSourceUrl = null,
+                    topToastMessage = "指定の URL から RSS フィードを見つけられませんでした。",
                 )
                 return@launch
             }
 
-            val sources = _uiState.value.rssSources
-            if (!sources.contains(resolvedRssUrl)) {
-                _uiState.value = _uiState.value.copy(rssSources = sources + resolvedRssUrl)
-                onAdded()
-            }
+            val current = _uiState.value.currentStep
+            _uiState.value = _uiState.value.copy(
+                rssSourceUrl = sourceUrl,
+                resolvedRssSourceUrl = resolvedRssUrl,
+                isResolvingRssSource = false,
+                currentStep = current + 1,
+            )
         }
-    }
-
-    // RSS ソースを削除する
-    fun removeRssSource(url: String) {
-        _uiState.value = _uiState.value.copy(
-            rssSources = _uiState.value.rssSources - url
-        )
     }
 
     // ユーザープロンプトを更新する
@@ -307,7 +335,7 @@ class WizardViewModel(
             it.copy(
                 googleAiApiKey = state.apiKey,
                 targetCalendarIds = state.selectedCalendarIds.toList(),
-                rssSources = state.rssSources,
+                rssSources = state.resolvedRssSourceUrl?.let { listOf(it) }.orEmpty(),
                 userPrompt = state.userPrompt,
                 autoGenerationEnabled = enableAutoGeneration,
                 schedule = state.schedule,
@@ -322,6 +350,11 @@ class WizardViewModel(
     // エラーメッセージをクリアする
     fun clearError() {
         _uiState.value = _uiState.value.copy(errorMessage = null)
+    }
+
+    // 上部 Toast メッセージをクリアする
+    fun clearTopToastMessage() {
+        _uiState.value = _uiState.value.copy(topToastMessage = null)
     }
 
     companion object {


### PR DESCRIPTION
## 概要
- Android の初回ウィザードで RSS ニュースソースを単一 URL 入力に変更
- 追加ボタンと追加済みリストをなくし、コンテキスト設定ステップの「次へ」で RSS URL を解決
- RSS フィードを見つけられない場合は遷移せず、キーボード表示中でも見える上部 Toast で通知

## 背景
Issue #159 では、ニュース URL を入力したまま追加ボタンを押さずに次へ進めてしまうため、設定漏れが起きやすい状態でした。最新の iOS 初回セットアップ実装は単一 `rssURL` を「次へ」で確認する仕様のため、Android ウィザードも同じ流れに寄せています。

## 影響範囲
- Android の初回ウィザードのみ
- 通常のデータ設定画面や `AppConfig.rssSources` の保存形式は変更なし

## 確認
- `git diff --check`
- `ANDROID_HOME=/Users/jin/Library/Android/sdk ANDROID_SDK_ROOT=/Users/jin/Library/Android/sdk ./scripts/build-android-debug.sh`

Fixes #159