### PR TITLE
[codex] iOS: Show calendar event details

### DIFF
--- a/WondayWall.iOS/WondayWall/App/AppEnvironment.swift
+++ b/WondayWall.iOS/WondayWall/App/AppEnvironment.swift
@@ -23,6 +23,8 @@ final class AppEnvironment: ObservableObject {
 
     // ウィジェットから生成確認シートを開く要求。HomeView が消費する。
     @Published var pendingWidgetGenerationSlotStartedAt: Date? = nil
+    // ウィジェットから予定詳細シートを開く要求。HomeView が消費する。
+    @Published var pendingWidgetCalendarEventID: String? = nil
 
     // 生成中かどうか（手動・起動時補完・バックグラウンド両方を含む）
     var isGenerating: Bool { generationProgress != nil }
@@ -144,5 +146,13 @@ final class AppEnvironment: ObservableObject {
 
     func clearWidgetGenerationConfirmationRequest() {
         pendingWidgetGenerationSlotStartedAt = nil
+    }
+
+    func requestWidgetCalendarEventDetail(eventID: String) {
+        pendingWidgetCalendarEventID = eventID
+    }
+
+    func clearWidgetCalendarEventDetailRequest() {
+        pendingWidgetCalendarEventID = nil
     }
 }

--- a/WondayWall.iOS/WondayWall/Models/CalendarEventDetail.swift
+++ b/WondayWall.iOS/WondayWall/Models/CalendarEventDetail.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+// 予定詳細シートで表示する一時データ
+struct CalendarEventDetail: Identifiable {
+    let id: String
+    let title: String
+    let startTime: Date
+    let endTime: Date?
+    let isAllDay: Bool
+    let location: String?
+    let notes: String?
+    let calendarTitle: String?
+    let calendarColorHex: String?
+    let urlString: String?
+    let organizerName: String?
+    let attendeeNames: [String]
+    let isLiveEventKitData: Bool
+
+    init(
+        id: String,
+        title: String,
+        startTime: Date,
+        endTime: Date?,
+        isAllDay: Bool,
+        location: String?,
+        notes: String?,
+        calendarTitle: String?,
+        calendarColorHex: String?,
+        urlString: String?,
+        organizerName: String?,
+        attendeeNames: [String],
+        isLiveEventKitData: Bool
+    ) {
+        self.id = id
+        self.title = title
+        self.startTime = startTime
+        self.endTime = endTime
+        self.isAllDay = isAllDay
+        self.location = location
+        self.notes = notes
+        self.calendarTitle = calendarTitle
+        self.calendarColorHex = calendarColorHex
+        self.urlString = urlString
+        self.organizerName = organizerName
+        self.attendeeNames = attendeeNames
+        self.isLiveEventKitData = isLiveEventKitData
+    }
+
+    init(savedEvent: CalendarEventItem) {
+        self.init(
+            id: savedEvent.id,
+            title: savedEvent.title,
+            startTime: savedEvent.startTime,
+            endTime: savedEvent.endTime,
+            isAllDay: savedEvent.isAllDay,
+            location: savedEvent.location,
+            notes: savedEvent.notes,
+            calendarTitle: nil,
+            calendarColorHex: nil,
+            urlString: nil,
+            organizerName: nil,
+            attendeeNames: [],
+            isLiveEventKitData: false
+        )
+    }
+}

--- a/WondayWall.iOS/WondayWall/Services/EventKitCalendarService.swift
+++ b/WondayWall.iOS/WondayWall/Services/EventKitCalendarService.swift
@@ -1,4 +1,6 @@
+import CoreGraphics
 import EventKit
+import Foundation
 
 // EventKit を使って標準カレンダーへアクセスするサービス
 // Google / iCloud / Exchange / CalDAV / 購読カレンダーをまとめて扱う
@@ -38,5 +40,118 @@ final class EventKitCalendarService {
         )
         return eventStore.events(matching: predicate)
             .sorted { $0.startDate < $1.startDate }
+    }
+
+    // 保存済み予定をもとに EventKit から現在の詳細情報を取得する
+    func fetchEventDetail(for savedEvent: CalendarEventItem) -> CalendarEventDetail? {
+        guard authorizationStatus() == .fullAccess else { return nil }
+
+        if let event = eventStore.event(withIdentifier: savedEvent.id) {
+            return makeDetail(from: event, savedEvent: savedEvent)
+        }
+
+        guard let event = findMatchingEvent(for: savedEvent) else { return nil }
+        return makeDetail(from: event, savedEvent: savedEvent)
+    }
+
+    private func findMatchingEvent(for savedEvent: CalendarEventItem) -> EKEvent? {
+        let queryStart = savedEvent.startTime.addingTimeInterval(-12 * 60 * 60)
+        let queryEndBase = savedEvent.endTime ?? savedEvent.startTime
+        let queryEnd = queryEndBase.addingTimeInterval(12 * 60 * 60)
+        let matchingCalendars = fetchCalendars()
+            .filter { $0.calendarIdentifier == savedEvent.calendarId }
+
+        if let match = searchMatchingEvent(
+            savedEvent,
+            from: queryStart,
+            to: queryEnd,
+            calendars: matchingCalendars.isEmpty ? nil : matchingCalendars
+        ) {
+            return match
+        }
+
+        return searchMatchingEvent(savedEvent, from: queryStart, to: queryEnd, calendars: nil)
+    }
+
+    private func searchMatchingEvent(
+        _ savedEvent: CalendarEventItem,
+        from start: Date,
+        to end: Date,
+        calendars: [EKCalendar]?
+    ) -> EKEvent? {
+        fetchEvents(from: start, to: end, calendars: calendars)
+            .first { event in
+                normalized(event.title) == normalized(savedEvent.title)
+                    && abs(event.startDate.timeIntervalSince(savedEvent.startTime)) < 60
+            }
+    }
+
+    private func makeDetail(from event: EKEvent, savedEvent: CalendarEventItem) -> CalendarEventDetail {
+        CalendarEventDetail(
+            id: event.eventIdentifier ?? savedEvent.id,
+            title: nonEmpty(event.title) ?? savedEvent.title,
+            startTime: event.startDate,
+            endTime: event.endDate,
+            isAllDay: event.isAllDay,
+            location: nonEmpty(event.location),
+            notes: nonEmpty(event.notes),
+            calendarTitle: nonEmpty(event.calendar.title),
+            calendarColorHex: colorHex(event.calendar.cgColor),
+            urlString: nonEmpty(event.url?.absoluteString),
+            organizerName: participantName(event.organizer),
+            attendeeNames: attendeeNames(event.attendees),
+            isLiveEventKitData: true
+        )
+    }
+
+    private func attendeeNames(_ attendees: [EKParticipant]?) -> [String] {
+        var seen: Set<String> = []
+        return (attendees ?? []).compactMap { participant in
+            guard let name = participantName(participant), !seen.contains(name) else { return nil }
+            seen.insert(name)
+            return name
+        }
+    }
+
+    private func participantName(_ participant: EKParticipant?) -> String? {
+        guard let participant else { return nil }
+        return nonEmpty(participant.name)
+            ?? nonEmpty(participant.url.absoluteString)
+    }
+
+    private func normalized(_ value: String?) -> String {
+        nonEmpty(value) ?? ""
+    }
+
+    private func nonEmpty(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    // CGColor を "#RRGGBB" 16進数文字列に変換する
+    private func colorHex(_ cgColor: CGColor?) -> String? {
+        guard let components = cgColor?.components else { return nil }
+        let red: CGFloat
+        let green: CGFloat
+        let blue: CGFloat
+
+        if components.count >= 3 {
+            red = components[0]
+            green = components[1]
+            blue = components[2]
+        } else if let white = components.first {
+            red = white
+            green = white
+            blue = white
+        } else {
+            return nil
+        }
+
+        return String(
+            format: "#%02X%02X%02X",
+            Int(red * 255),
+            Int(green * 255),
+            Int(blue * 255)
+        )
     }
 }

--- a/WondayWall.iOS/WondayWall/Services/HistoryService.swift
+++ b/WondayWall.iOS/WondayWall/Services/HistoryService.swift
@@ -131,6 +131,14 @@ final class HistoryService {
         return getLastSuccessfulGenerated()?.usedCalendarEvents ?? []
     }
 
+    // 保存済み履歴から指定 ID の予定を探す
+    func findCalendarEvent(id: String) -> CalendarEventItem? {
+        loadNewestFirst()
+            .compactMap { $0.usedCalendarEvents }
+            .flatMap { $0 }
+            .first { $0.id == id }
+    }
+
     // プロンプト生成済み・画像 API 未呼び出しの再開可能な履歴を返す
     // generatingPromptReady: 画像 API を呼ぶ前に kill されたため再開可能
     func getGeneratingWithPrompt() -> HistoryItem? {

--- a/WondayWall.iOS/WondayWall/Views/ContentView.swift
+++ b/WondayWall.iOS/WondayWall/Views/ContentView.swift
@@ -223,6 +223,15 @@ struct ContentView: View {
             selectedTab = 0
             startupAlertMode = nil
             showStartupAlert = false
+        case "/calendar-event":
+            guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+                  let eventID = components.queryItems?.first(where: { $0.name == "eventId" })?.value
+            else { return }
+
+            selectedTab = 0
+            startupAlertMode = nil
+            showStartupAlert = false
+            environment.requestWidgetCalendarEventDetail(eventID: eventID)
         default:
             return
         }

--- a/WondayWall.iOS/WondayWall/Views/Home/HomeView.swift
+++ b/WondayWall.iOS/WondayWall/Views/Home/HomeView.swift
@@ -53,6 +53,7 @@ struct HomeView: View {
 private struct HomeContentView: View {
     @EnvironmentObject private var environment: AppEnvironment
     @Environment(\.openURL) private var openURL
+    @State private var selectedCalendarEvent: CalendarEventItem?
     var vm: HomeViewModel
 
     var body: some View {
@@ -104,6 +105,12 @@ private struct HomeContentView: View {
             )) {
                 GenerationConfirmSheet(vm: vm)
             }
+            .sheet(item: $selectedCalendarEvent) { event in
+                CalendarEventDetailSheet(
+                    event: event,
+                    calendarService: environment.calendarService
+                )
+            }
             .background{
                 // 最新壁紙を全画面背景として表示する（タブバー裏まで伸ばす）
                 if let image = vm.latestImage {
@@ -147,39 +154,61 @@ private struct HomeContentView: View {
                         Divider()
                             .padding(.leading, 12)
                     }
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(event.title).font(.subheadline)
-                        HStack {
-                            if event.isAllDay {
-                                Text(event.startTime, style: .date)
-                                    .font(.caption).foregroundStyle(.secondary)
-                                Text("終日")
-                                    .font(.caption).foregroundStyle(.secondary)
-                            } else {
-                                Text(event.startTime, style: .date)
-                                    .font(.caption).foregroundStyle(.secondary)
-                                Text(event.startTime, style: .time)
-                                    .font(.caption).foregroundStyle(.secondary)
-                            }
-                            if let location = event.location {
-                                Text("·")
-                                    .foregroundStyle(.secondary)
-                                Text(location)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                                    .lineLimit(1)
-                            }
-                        }
+                    Button {
+                        selectedCalendarEvent = event
+                    } label: {
+                        calendarEventRow(event)
                     }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 10)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.primary)
                 }
             }
             .background(AnyShapeStyle(.regularMaterial))
             .cornerRadius(10)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func calendarEventRow(_ event: CalendarEventItem) -> some View {
+        HStack(alignment: .center, spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(event.title).font(.subheadline)
+                HStack {
+                    if event.isAllDay {
+                        Text(event.startTime, style: .date)
+                            .font(.caption).foregroundStyle(.secondary)
+                        Text("終日")
+                            .font(.caption).foregroundStyle(.secondary)
+                    } else {
+                        Text(event.startTime, style: .date)
+                            .font(.caption).foregroundStyle(.secondary)
+                        Text(event.startTime, style: .time)
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                    if let location = displayText(event.location) {
+                        Text("·")
+                            .foregroundStyle(.secondary)
+                        Text(location)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+            }
+            Spacer(minLength: 8)
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func displayText(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     // 使用したニュース一覧
@@ -279,6 +308,170 @@ private struct HomeContentView: View {
         if item.isSkipped { return "前回: スキップ" }
         if item.isSuccess { return "前回: 生成成功" }
         return "前回: 失敗"
+    }
+}
+
+// 予定詳細シート — 保存済み情報を表示しつつ EventKit から最新詳細を取得する
+private struct CalendarEventDetailSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    private let event: CalendarEventItem
+    private let calendarService: EventKitCalendarService
+    @State private var detail: CalendarEventDetail
+    @State private var isLoadingDetail = false
+    @State private var didAttemptLoad = false
+
+    init(event: CalendarEventItem, calendarService: EventKitCalendarService) {
+        self.event = event
+        self.calendarService = calendarService
+        _detail = State(initialValue: CalendarEventDetail(savedEvent: event))
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if isLoadingDetail {
+                    Section {
+                        HStack(spacing: 10) {
+                            ProgressView()
+                            Text("予定の詳細を取得中...")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                } else if didAttemptLoad && !detail.isLiveEventKitData {
+                    Section {
+                        Label("保存済みの予定情報を表示しています", systemImage: "tray")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Section("予定") {
+                    detailRow(title: "タイトル", value: detail.title)
+                    detailRow(
+                        title: "日付",
+                        value: detail.startTime.formatted(date: .abbreviated, time: .omitted)
+                    )
+                    if detail.isAllDay {
+                        detailRow(title: "時間", value: "終日予定")
+                    } else {
+                        detailRow(
+                            title: "開始",
+                            value: detail.startTime.formatted(date: .abbreviated, time: .shortened)
+                        )
+                        if let endTime = detail.endTime {
+                            detailRow(
+                                title: "終了",
+                                value: endTime.formatted(date: .abbreviated, time: .shortened)
+                            )
+                        }
+                    }
+                    calendarRow
+                    optionalRow(title: "場所", value: detail.location)
+                    urlRow
+                    optionalRow(title: "主催者", value: detail.organizerName)
+                }
+
+                if !detail.attendeeNames.isEmpty {
+                    Section("参加者") {
+                        ForEach(detail.attendeeNames, id: \.self) { attendeeName in
+                            Text(attendeeName)
+                        }
+                    }
+                }
+
+                if let notes = displayText(detail.notes) {
+                    Section("メモ") {
+                        Text(notes)
+                    }
+                }
+            }
+            .navigationTitle("予定詳細")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("閉じる") { dismiss() }
+                }
+            }
+        }
+        .task(id: event.id) {
+            await loadDetail()
+        }
+    }
+
+    @ViewBuilder
+    private var calendarRow: some View {
+        if let calendarTitle = displayText(detail.calendarTitle) {
+            HStack(alignment: .top) {
+                Text("カレンダー")
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 16)
+                HStack(spacing: 6) {
+                    if let colorHex = detail.calendarColorHex,
+                       let color = Color(hex: colorHex) {
+                        Circle()
+                            .fill(color)
+                            .frame(width: 10, height: 10)
+                    }
+                    Text(calendarTitle)
+                        .multilineTextAlignment(.trailing)
+                }
+                .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var urlRow: some View {
+        if let urlString = displayText(detail.urlString) {
+            if let url = URL(string: urlString) {
+                Link(destination: url) {
+                    HStack(alignment: .top) {
+                        Text("URL")
+                            .foregroundStyle(.secondary)
+                        Spacer(minLength: 16)
+                        Text(urlString)
+                            .multilineTextAlignment(.trailing)
+                    }
+                }
+            } else {
+                detailRow(title: "URL", value: urlString)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func optionalRow(title: String, value: String?) -> some View {
+        if let value = displayText(value) {
+            detailRow(title: title, value: value)
+        }
+    }
+
+    private func detailRow(title: String, value: String) -> some View {
+        HStack(alignment: .top) {
+            Text(title)
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 16)
+            Text(value)
+                .multilineTextAlignment(.trailing)
+        }
+    }
+
+    @MainActor
+    private func loadDetail() async {
+        guard !isLoadingDetail else { return }
+        isLoadingDetail = true
+        didAttemptLoad = true
+        defer { isLoadingDetail = false }
+
+        if let liveDetail = calendarService.fetchEventDetail(for: event) {
+            detail = liveDetail
+        }
+    }
+
+    private func displayText(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
     }
 }
 

--- a/WondayWall.iOS/WondayWall/Views/Home/HomeView.swift
+++ b/WondayWall.iOS/WondayWall/Views/Home/HomeView.swift
@@ -4,12 +4,13 @@ import SwiftUI
 struct HomeView: View {
     @EnvironmentObject private var environment: AppEnvironment
     @State private var viewModel: HomeViewModel?
+    @State private var selectedCalendarEvent: CalendarEventItem?
 
     var body: some View {
         NavigationStack {
             Group {
                 if let vm = viewModel {
-                    HomeContentView(vm: vm)
+                    HomeContentView(selectedCalendarEvent: $selectedCalendarEvent, vm: vm)
                 } else {
                     ProgressView()
                 }
@@ -25,6 +26,12 @@ struct HomeView: View {
                 }
             }
         }
+        .sheet(item: $selectedCalendarEvent) { event in
+            CalendarEventDetailSheet(
+                event: event,
+                calendarService: environment.calendarService
+            )
+        }
         .task {
             if viewModel == nil {
                 viewModel = HomeViewModel(environment: environment)
@@ -32,12 +39,19 @@ struct HomeView: View {
             if let slotStartedAt = environment.pendingWidgetGenerationSlotStartedAt {
                 await handleWidgetGenerationRequest(slotStartedAt)
             }
+            if let eventID = environment.pendingWidgetCalendarEventID {
+                handleWidgetCalendarEventRequest(eventID)
+            }
         }
         .onReceive(environment.$pendingWidgetGenerationSlotStartedAt) { slotStartedAt in
             guard let slotStartedAt else { return }
             Task {
                 await handleWidgetGenerationRequest(slotStartedAt)
             }
+        }
+        .onReceive(environment.$pendingWidgetCalendarEventID) { eventID in
+            guard let eventID else { return }
+            handleWidgetCalendarEventRequest(eventID)
         }
     }
 
@@ -47,13 +61,20 @@ struct HomeView: View {
         await viewModel.openGenerationSheetIfStillAllowed(slotStartedAt: slotStartedAt)
         environment.clearWidgetGenerationConfirmationRequest()
     }
+
+    @MainActor
+    private func handleWidgetCalendarEventRequest(_ eventID: String) {
+        defer { environment.clearWidgetCalendarEventDetailRequest() }
+        guard let event = environment.historyService.findCalendarEvent(id: eventID) else { return }
+        selectedCalendarEvent = event
+    }
 }
 
 // ホーム画面のコンテンツ本体
 private struct HomeContentView: View {
     @EnvironmentObject private var environment: AppEnvironment
     @Environment(\.openURL) private var openURL
-    @State private var selectedCalendarEvent: CalendarEventItem?
+    @Binding var selectedCalendarEvent: CalendarEventItem?
     var vm: HomeViewModel
 
     var body: some View {
@@ -104,12 +125,6 @@ private struct HomeContentView: View {
                 set: { vm.showGenerationSheet = $0 }
             )) {
                 GenerationConfirmSheet(vm: vm)
-            }
-            .sheet(item: $selectedCalendarEvent) { event in
-                CalendarEventDetailSheet(
-                    event: event,
-                    calendarService: environment.calendarService
-                )
             }
             .background{
                 // 最新壁紙を全画面背景として表示する（タブバー裏まで伸ばす）
@@ -197,10 +212,8 @@ private struct HomeContentView: View {
                 }
             }
             Spacer(minLength: 8)
-            Image(systemName: "chevron.right")
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
         }
+        .contentShape(Rectangle())
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/WondayWall.iOS/WondayWallWidget/WondayWallWidget.swift
+++ b/WondayWall.iOS/WondayWallWidget/WondayWallWidget.swift
@@ -533,7 +533,9 @@ struct WondayWallWidgetView: View {
                     Divider()
                         .padding(.leading, compact ? 8 : 10)
                 }
-                calendarRow(item, compact: compact)
+                Link(destination: calendarEventURL(for: item)) {
+                    calendarRow(item, compact: compact)
+                }
             }
             if showMore {
                 Divider()
@@ -760,6 +762,17 @@ struct WondayWallWidgetView: View {
 
     private var widgetNewsURL: URL {
         URL(string: "wondaywall://widget/news")!
+    }
+
+    private func calendarEventURL(for item: WidgetCalendarEvent) -> URL {
+        var components = URLComponents()
+        components.scheme = "wondaywall"
+        components.host = "widget"
+        components.path = "/calendar-event"
+        components.queryItems = [
+            URLQueryItem(name: "eventId", value: item.id)
+        ]
+        return components.url ?? URL(string: "wondaywall://widget/calendar-event")!
     }
 
     private var rootWidgetURL: URL? {


### PR DESCRIPTION
## Summary
- Make the Home screen "使用した予定" rows tappable and present an in-app event detail sheet without adding row chevrons.
- Re-fetch the tapped event from EventKit when the sheet opens, showing extra live details such as calendar, URL, organizer, and attendees when available.
- Fall back to the saved `CalendarEventItem` data when EventKit access fails or the original event no longer exists.
- Open the app from Widget calendar-event taps and present the same event detail sheet.

Closes #183

## Validation
- `xcodegen generate`
- XcodeBuildMCP `build_sim` / Debug / iPhone 17 Pro
- `git diff --check`
