### PR TITLE
Increase open pull requests limit in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     cooldown:
       default-days: 14
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     cooldown:
       default-days: 14


### PR DESCRIPTION
Increased the open pull requests limit for NuGet and GitHub Actions.