### PR TITLE
StoreアップロードにMSIXディレクトリを渡す

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -257,9 +257,10 @@ jobs:
           if (-not $msixPath) {
             throw "No MSIX file found in msix-artifacts. Ensure the installer job produced a WondayWall-*.msix artifact."
           }
+          $msixDirectory = Split-Path -Parent $msixPath
 
           msstore publish `
-            -i "$msixPath" `
+            -i "$msixDirectory" `
             -id "${{ vars.MSSTORE_PRODUCT_ID }}" `
             -f "${{ vars.MSSTORE_FLIGHT_ID }}" `
             --noCommit


### PR DESCRIPTION
## 変更内容

- `msstore publish` の `-i` に MSIX ファイルではなく、その格納ディレクトリを渡すよう修正しました。

## 原因

`microsoft/microsoft-store-apppublisher@v1` が導入する現在の Store CLI では、`-i` は `--inputDirectory` です。MSIX ファイルパスを直接渡していたため、main の実行で `Input directory does not exist.` となっていました。

## 影響

main またはタグのビルドで、生成した MSIX を `main-build` package flight に下書きとしてアップロードできるようになります。

## 確認

- `SELLER_ID` を Partner Center の Developer 情報と照合し、正しい値へ更新
- 再実行で Partner Center 認証が成功することを確認
- Store CLI の実行ログで `-i, --inputDirectory` の仕様を確認
- `git diff --check` 実行済み