### PR TITLE
Store CLI に MSIX ファイルを明示してアップロードを修正

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -257,10 +257,8 @@ jobs:
           if (-not $msixPath) {
             throw "No MSIX file found in msix-artifacts. Ensure the installer job produced a WondayWall-*.msix artifact."
           }
-          $msixDirectory = Split-Path -Parent $msixPath
-
           msstore publish `
-            -i "$msixDirectory" `
+            "$msixPath" `
             -id "${{ vars.MSSTORE_PRODUCT_ID }}" `
             -f "${{ vars.MSSTORE_FLIGHT_ID }}" `
             --noCommit


### PR DESCRIPTION
## 概要

main の Store アップロードジョブで、`msstore publish` がリポジトリ直下をプロジェクトとして解析し、Publisher を検出できず失敗していました。

## 変更

- `msstore publish` の位置引数に、生成済み MSIX のフルパスを渡す
- 不要になった `--inputDirectory` とディレクトリ算出を削除

Microsoft Store CLI の現行実装では、MSIX を直接発行する場合は位置引数に `.msix` ファイルを渡すことで `MSIXProjectPublisher` が選択されます。

## 確認

- `git diff --check` 済み
- 失敗した main ジョブ: https://github.com/Freeesia/WondayWall/actions/runs/29293795901