### PR TITLE
設定済みの Store FlightId を使用する

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -250,31 +250,6 @@ jobs:
             --clientSecret "${{ secrets.AZURE_AD_APPLICATION_SECRET }}" `
             --sellerId "${{ secrets.SELLER_ID }}"
 
-      - name: Resolve main-build package flight ID
-        id: resolve-flight
-        run: |
-          $flightList = msstore flights list "${{ vars.MSSTORE_PRODUCT_ID }}" | Out-String
-          if ($LASTEXITCODE -ne 0) {
-            throw "Failed to retrieve package flights."
-          }
-          Write-Host $flightList
-
-          $flightLine = $flightList -split "`r?`n" |
-            Where-Object { $_ -match '\bmain-build\b' } |
-            Select-Object -First 1
-          if (-not $flightLine) {
-            throw "Could not find the main-build package flight."
-          }
-          $flightId = [regex]::Match(
-            $flightLine,
-            '(?i)[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}'
-          ).Value
-          if (-not $flightId) {
-            throw "Could not resolve the FlightId for the main-build package flight."
-          }
-
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "flight_id=$flightId"
-
       - name: Upload MSIX to main-build package flight
         run: |
           $msixPath = Get-ChildItem -Path msix-artifacts -Filter "*.msix" |
@@ -285,7 +260,7 @@ jobs:
           msstore publish `
             "$msixPath" `
             -id "${{ vars.MSSTORE_PRODUCT_ID }}" `
-            -f "${{ steps.resolve-flight.outputs.flight_id }}" `
+            -f "${{ vars.MSSTORE_FLIGHT_ID }}" `
             --noCommit
 
       - name: Publish main-build package flight submission
@@ -293,4 +268,4 @@ jobs:
         run: |
           msstore flights submission publish `
             "${{ vars.MSSTORE_PRODUCT_ID }}" `
-            "${{ steps.resolve-flight.outputs.flight_id }}"
+            "${{ vars.MSSTORE_FLIGHT_ID }}"


### PR DESCRIPTION
## 概要

`msstore flights list` の実行ログから、`main-build` の Store API 用 FlightId が `886b62ca-1d0a-4674-9b80-1f6818ef3dc3` であることを確認しました。

前回の動的解決は Store CLI の表が端末幅で折り返され、GUID が複数行に分割されるため失敗しました。

## 変更

- 折り返しに依存する package flight 一覧の解析を削除
- upload とタグ時の publish で `MSSTORE_FLIGHT_ID` 変数を使用

Repository variable `MSSTORE_FLIGHT_ID` は上記 GUID へ更新します。

## 確認

- Partner Center の `main-build` と CLI の `FriendlyName` を照合
- CLI 一覧で FlightId を確認
- `git diff --check` 済み
- 失敗した main ジョブ: https://github.com/Freeesia/WondayWall/actions/runs/29305832403