### PR TITLE
MSIXのビルド番号をパッケージ版数に反映

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -92,6 +92,7 @@ jobs:
       contents: read
     outputs:
       version: ${{ steps.gitversion.outputs.assemblySemFileVer }}
+      msix_version: ${{ steps.build_number.outputs.version }}
     steps:
       - uses: actions/checkout@v7.0.0
         with:
@@ -110,6 +111,25 @@ jobs:
           versionSpec: "6.x"
       - id: gitversion
         uses: gittools/actions/gitversion/execute@v4.5.0
+      - id: build_number
+        name: Determine MSIX build number
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $versionComponents = '${{ steps.gitversion.outputs.assemblySemFileVer }}'.Split('.')
+          if ($versionComponents.Count -ne 4) {
+            throw "GitVersion did not produce a four-part file version."
+          }
+
+          $buildNumber = [int](git rev-list --count HEAD)
+          if ($buildNumber -gt 65535) {
+            throw "The MSIX build number $buildNumber exceeds the maximum value 65535."
+          }
+
+          $versionComponents[3] = $buildNumber.ToString()
+          $msixVersion = $versionComponents -join '.'
+          "version=$msixVersion" >> $env:GITHUB_OUTPUT
+          Write-Host "MSIX version: $msixVersion"
       - uses: actions/download-artifact@v8
         with:
           name: licenses
@@ -175,7 +195,7 @@ jobs:
       - name: Generate MSIX
         shell: pwsh
         run: |
-          $version = '${{ needs.build.outputs.version }}'
+          $version = '${{ needs.build.outputs.msix_version }}'
 
           # Windows SDK に同梱の makeappx.exe を検索
           $makeappx = Get-ChildItem 'C:\Program Files (x86)\Windows Kits\10\bin' -Filter 'makeappx.exe' -Recurse -ErrorAction SilentlyContinue |
@@ -222,7 +242,7 @@ jobs:
 
       - uses: actions/upload-artifact@v7
         with:
-          name: WondayWall-${{ needs.build.outputs.version }}.msix
+          name: WondayWall-${{ needs.build.outputs.msix_version }}.msix
           path: publish\*.msix
 
   store-upload:
@@ -250,14 +270,83 @@ jobs:
             --clientSecret "${{ secrets.AZURE_AD_APPLICATION_SECRET }}" `
             --sellerId "${{ secrets.SELLER_ID }}"
 
-      - name: Upload MSIX to main-build package flight
+      - name: Replace pending submission and upload MSIX to main-build package flight
+        shell: pwsh
         run: |
+          $ErrorActionPreference = 'Stop'
+          $productId = "${{ vars.MSSTORE_PRODUCT_ID }}"
+          $flightId = "${{ vars.MSSTORE_FLIGHT_ID }}"
+
+          function Get-PackageFlight {
+            $output = & msstore flights get $productId $flightId | Out-String
+            if ($LASTEXITCODE -ne 0) {
+              throw "Could not retrieve package flight '$flightId'."
+            }
+
+            try {
+              return $output | ConvertFrom-Json
+            }
+            catch {
+              throw "Could not parse package flight '$flightId'."
+            }
+          }
+
           $msixPath = Get-ChildItem -Path msix-artifacts -Filter "*.msix" |
             Select-Object -First 1 -ExpandProperty FullName
           if (-not $msixPath) {
             throw "No MSIX file found in msix-artifacts. Ensure the installer job produced a WondayWall-*.msix artifact."
           }
-          msstore publish `
-            "$msixPath" `
-            -id "${{ vars.MSSTORE_PRODUCT_ID }}" `
-            -f "${{ vars.MSSTORE_FLIGHT_ID }}"
+
+          $flight = Get-PackageFlight
+          if ($null -ne $flight.pendingFlightSubmission) {
+            if ($null -eq $flight.lastPublishedFlightSubmission) {
+              throw "The first submission is still pending. Publish it once before enabling automatic replacement."
+            }
+
+            Write-Host "Canceling pending submission '$($flight.pendingFlightSubmission.id)'..."
+            & msstore flights submission delete $productId $flightId --no-confirm
+            if ($LASTEXITCODE -ne 0) {
+              Write-Warning "The pending submission could not be canceled. Waiting for it to finish instead."
+              & msstore flights submission poll $productId $flightId
+              if ($LASTEXITCODE -ne 0) {
+                throw "The pending submission could not be canceled or completed successfully."
+              }
+            }
+
+            for ($attempt = 1; $attempt -le 12; $attempt++) {
+              $flight = Get-PackageFlight
+              if ($null -eq $flight.pendingFlightSubmission) {
+                break
+              }
+              if ($attempt -eq 12) {
+                throw "Pending submission was not removed within 120 seconds."
+              }
+              Write-Host "Waiting for pending submission removal ($attempt/12)..."
+              Start-Sleep -Seconds 10
+            }
+          }
+
+          for ($attempt = 1; $attempt -le 5; $attempt++) {
+            & msstore publish `
+              "$msixPath" `
+              -id $productId `
+              -f $flightId
+            $publishExitCode = $LASTEXITCODE
+
+            if ($publishExitCode -eq 0) {
+              break
+            }
+
+            if ($attempt -eq 5) {
+              throw "Publishing the package flight submission failed after 5 attempts."
+            }
+
+            $flight = Get-PackageFlight
+            if ($null -ne $flight.pendingFlightSubmission) {
+              throw "Publishing failed after creating pending submission '$($flight.pendingFlightSubmission.id)'. It was preserved for the next run."
+            }
+
+            $retryDelay = 15 * $attempt
+            Write-Warning "Submission creation failed. Retrying in $retryDelay seconds ($attempt/5)..."
+            Start-Sleep -Seconds $retryDelay
+          }

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -116,18 +116,13 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $versionComponents = '${{ steps.gitversion.outputs.assemblySemFileVer }}'.Split('.')
-          if ($versionComponents.Count -ne 4) {
-            throw "GitVersion did not produce a four-part file version."
-          }
-
+          $version = [Version]'${{ steps.gitversion.outputs.assemblySemFileVer }}'
           $buildNumber = [int](git rev-list --count HEAD)
-          if ($buildNumber -gt 65535) {
+          if ($buildNumber -gt [uint16]::MaxValue) {
             throw "The MSIX build number $buildNumber exceeds the maximum value 65535."
           }
 
-          $versionComponents[3] = $buildNumber.ToString()
-          $msixVersion = $versionComponents -join '.'
+          $msixVersion = [Version]::new($version.Major, $version.Minor, $version.Build, $buildNumber)
           "version=$msixVersion" >> $env:GITHUB_OUTPUT
           Write-Host "MSIX version: $msixVersion"
       - uses: actions/download-artifact@v8
@@ -270,83 +265,14 @@ jobs:
             --clientSecret "${{ secrets.AZURE_AD_APPLICATION_SECRET }}" `
             --sellerId "${{ secrets.SELLER_ID }}"
 
-      - name: Replace pending submission and upload MSIX to main-build package flight
-        shell: pwsh
+      - name: Upload MSIX to main-build package flight
         run: |
-          $ErrorActionPreference = 'Stop'
-          $productId = "${{ vars.MSSTORE_PRODUCT_ID }}"
-          $flightId = "${{ vars.MSSTORE_FLIGHT_ID }}"
-
-          function Get-PackageFlight {
-            $output = & msstore flights get $productId $flightId | Out-String
-            if ($LASTEXITCODE -ne 0) {
-              throw "Could not retrieve package flight '$flightId'."
-            }
-
-            try {
-              return $output | ConvertFrom-Json
-            }
-            catch {
-              throw "Could not parse package flight '$flightId'."
-            }
-          }
-
           $msixPath = Get-ChildItem -Path msix-artifacts -Filter "*.msix" |
             Select-Object -First 1 -ExpandProperty FullName
           if (-not $msixPath) {
             throw "No MSIX file found in msix-artifacts. Ensure the installer job produced a WondayWall-*.msix artifact."
           }
-
-          $flight = Get-PackageFlight
-          if ($null -ne $flight.pendingFlightSubmission) {
-            if ($null -eq $flight.lastPublishedFlightSubmission) {
-              throw "The first submission is still pending. Publish it once before enabling automatic replacement."
-            }
-
-            Write-Host "Canceling pending submission '$($flight.pendingFlightSubmission.id)'..."
-            & msstore flights submission delete $productId $flightId --no-confirm
-            if ($LASTEXITCODE -ne 0) {
-              Write-Warning "The pending submission could not be canceled. Waiting for it to finish instead."
-              & msstore flights submission poll $productId $flightId
-              if ($LASTEXITCODE -ne 0) {
-                throw "The pending submission could not be canceled or completed successfully."
-              }
-            }
-
-            for ($attempt = 1; $attempt -le 12; $attempt++) {
-              $flight = Get-PackageFlight
-              if ($null -eq $flight.pendingFlightSubmission) {
-                break
-              }
-              if ($attempt -eq 12) {
-                throw "Pending submission was not removed within 120 seconds."
-              }
-              Write-Host "Waiting for pending submission removal ($attempt/12)..."
-              Start-Sleep -Seconds 10
-            }
-          }
-
-          for ($attempt = 1; $attempt -le 5; $attempt++) {
-            & msstore publish `
-              "$msixPath" `
-              -id $productId `
-              -f $flightId
-            $publishExitCode = $LASTEXITCODE
-
-            if ($publishExitCode -eq 0) {
-              break
-            }
-
-            if ($attempt -eq 5) {
-              throw "Publishing the package flight submission failed after 5 attempts."
-            }
-
-            $flight = Get-PackageFlight
-            if ($null -ne $flight.pendingFlightSubmission) {
-              throw "Publishing failed after creating pending submission '$($flight.pendingFlightSubmission.id)'. It was preserved for the next run."
-            }
-
-            $retryDelay = 15 * $attempt
-            Write-Warning "Submission creation failed. Retrying in $retryDelay seconds ($attempt/5)..."
-            Start-Sleep -Seconds $retryDelay
-          }
+          msstore publish `
+            "$msixPath" `
+            -id "${{ vars.MSSTORE_PRODUCT_ID }}" `
+            -f "${{ vars.MSSTORE_FLIGHT_ID }}"


### PR DESCRIPTION
## 変更内容

- GitVersion が生成した版数の第4要素を Git コミット数に置き換え
- 生成した版数を MSIX manifest と成果物名に使用
- パッケージフライトへのアップロードは `msstore publish` の標準処理を使用

## 背景

MSIX が常に `0.3.3.0` で生成され、Partner Center で同じ Package Full Name かつ内容が異なるパッケージとして拒否されていました。

`msstore publish` がフライト申請の作成、パッケージのアップロード、commit、完了待機を担当するため、独自の申請取得・削除・再試行処理は削除しました。

## 確認

- ワークフロー内の PowerShell ブロックを構文解析して実行
- 現在のコミットで MSIX 版数が `0.3.3.668` になることを確認
- `git diff --check` を実行
- 最終差分: 1ファイル、17行追加、2行削除